### PR TITLE
Added ability to establish the local IP address

### DIFF
--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -19,7 +19,6 @@ use cbor;
 use sodiumoxide::crypto::asymmetricbox;
 use std::collections::{HashMap, HashSet};
 use std::io;
-use std::net::{IpAddr, SocketAddr};
 use std::sync::{Arc, mpsc, Mutex, Weak};
 use std::thread;
 
@@ -256,27 +255,11 @@ impl ConnectionManager {
                 None => continue,
             };
             for contact in contact_list {
-                endpoints.push(self.replace_loopback(contact.end_point(),
-                                                     &transport.remote_endpoint));
+                endpoints.push(contact.end_point());
             }
         }
 
         endpoints
-    }
-
-    // Replace the IP in `original` with `replacement`'s IP if `original`'s is the loopback.
-    fn replace_loopback(&self, original: Endpoint, replacement: &Endpoint) -> Endpoint {
-        let is_loopback = match original.get_address().ip() {
-            IpAddr::V4(ip) => ip.is_loopback(),
-            IpAddr::V6(ip) => ip.is_loopback(),
-        };
-        if !is_loopback {
-            return original;
-        }
-        let port = original.get_address().port();
-        match *replacement {
-            Endpoint::Tcp(tcp_endpoint) => Endpoint::Tcp(SocketAddr::new(tcp_endpoint.ip(), port)),
-        }
     }
 
     fn bootstrap_off_list(&self, bootstrap_list: Vec<Endpoint>) -> io::Result<Endpoint> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 #![doc(html_logo_url = "http://maidsafe.net/img/Resources/branding/maidsafe_logo.fab2.png",
        html_favicon_url = "http://maidsafe.net/img/favicon.ico",
        html_root_url = "http:///dirvine.github.io/crust/crust/")]
-#![feature(ip, ip_addr, lookup_addr, lookup_host, alloc, udp, scoped)]
+#![feature(ip_addr, libc, lookup_host, alloc, udp, scoped)]
 
 extern crate cbor;
 extern crate rand;


### PR DESCRIPTION
I had to use an `unsafe` block round about [here](https://github.com/maidsafe/crust/compare/master...Fraser999:get_local_address?expand=1#diff-ec7d691b5cafdc631a44bf41efa29e95R210).  I'd have avoided this if I could, but I can't find a cleaner way to get the hostname, which is required in order to get the local interfaces.  The solution is drawn from [here](http://stackoverflow.com/a/20450716/2556117).

