### PR TITLE
MAID-1075 and MAID-1122 fix to make listening sockets never have an IP address

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ after_success: |
   ghp-import -n target/doc &&
   git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages;
   cargo clean;
-  RUST_TEST_TASKS=1 RUST_TEST_THREADS=1 cargo test --no-run;
+  cargo test --no-run;
   kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/crust-*;
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ after_success: |
   ghp-import -n target/doc &&
   git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages;
   cargo clean;
-  cargo test --no-run;
+  RUST_TEST_TASKS=1 RUST_TEST_THREADS=1 cargo test --no-run;
   kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/crust-*;
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ after_success: |
   ghp-import -n target/doc &&
   git push -fq https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages;
   cargo clean;
-  RUST_TEST_TASKS=1 RUST_TEST_THREADS=1 cargo test --no-run;
-  kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/crust-*;
+  cargo test --no-run;
+  RUST_TEST_TASKS=1 RUST_TEST_THREADS=1 kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo target/kcov target/debug/crust-*;
 env:
   global:
     secure: DzS6hBiuUQybrHDvXWDPNsyuUwCPVrfayRDR4tQwN90Uykr+X2ILpNjA/wxEJuGOsPQc1qsk1VStSIHbYJjHl1ahS9tQo+PU1oukuT0b2r9EKkIJOLoc9W53DbHzmLef5Qr4GxqoI5IGOcU9G9V7Lovefsm3gebSwL6xosbg8AY=

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
 - cd ../..
 script:
 - cargo build --verbose
-- RUST_TEST_THREADS=1 cargo test
+- RUST_TEST_TASKS=1 RUST_TEST_THREADS=1 cargo test
 after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crust"
-version = "0.0.8"
+version = "0.0.9"
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "p2p networking library. Automatically reconnect and manage connections."
 documentation = "http://maidsafe.github.io/crust/crust"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Several methods are used for NAT traversal, UpNP, hole punching [See here for TC
 ##Todo Items
 
 ## [0.0.9]
-- [ ] [MAID-1075](https://maidsafe.atlassian.net/browse/MAID-1075) Correct bug; listening on local port (127.0.0.1)
+- [x] [MAID-1075](https://maidsafe.atlassian.net/browse/MAID-1075) Correct bug; listening on local port (127.0.0.1)
 - [ ] Have ConnectionManager guarantee at most one connection between any two nodes
 - [ ] Utp Networking
   - [ ] Utp live port and backup random port selection

--- a/src/beacon.rs
+++ b/src/beacon.rs
@@ -141,7 +141,9 @@ impl BroadcastAcceptor {
         for i in 0..GUID_SIZE {
             guid[i] = random::<u8>();
         }
-        let tcp_listener_port = acceptor.local_endpoint().get_address().port();
+        let tcp_listener_port = match acceptor.local_port() {
+            Port::Tcp(p) => p
+        };
         Ok(BroadcastAcceptor{ guid: guid,
                               socket: socket,
                               acceptor: Arc::new(Mutex::new(acceptor)),

--- a/src/beacon.rs
+++ b/src/beacon.rs
@@ -141,9 +141,7 @@ impl BroadcastAcceptor {
         for i in 0..GUID_SIZE {
             guid[i] = random::<u8>();
         }
-        let tcp_listener_port = match acceptor.local_port() {
-            Port::Tcp(p) => p
-        };
+        let tcp_listener_port = acceptor.local_port().get_port();
         Ok(BroadcastAcceptor{ guid: guid,
                               socket: socket,
                               acceptor: Arc::new(Mutex::new(acceptor)),

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -26,6 +26,7 @@ use std::io::prelude::*;
 use std::path;
 use std::env;
 use std::fmt;
+use std::io;
 
 pub type BootStrapContacts = Vec<Contact>;
 
@@ -221,11 +222,11 @@ impl BootStrapHandler {
                     Ok(_) => {
                         content
                     },
-                    _ => panic!("Failed to read file")
+                    Err(e) => panic!("Failed to read bootstrap file due to {}", e)
 
                 }
             },
-            _ => panic!("Could not open file"),
+            Err(e) => panic!("Could not open bootstrap file due to {}", e),
         }
     }
 
@@ -243,8 +244,8 @@ impl BootStrapHandler {
     // }
 
     fn insert_bootstrap_contacts(&mut self, contacts: BootStrapContacts) {
-    	if !contacts.is_empty() {
-        	let mut current_contacts = BootStrapContacts::new();
+        if !contacts.is_empty() {
+            let mut current_contacts = BootStrapContacts::new();
             match File::open(&self.file_name) {
                 Ok(mut open_file) => {
                     let mut content = Vec::<u8>::new();
@@ -253,7 +254,12 @@ impl BootStrapHandler {
 
                     if size.is_ok() && size.unwrap() != 0 {
                         let mut decoder = cbor::Decoder::from_bytes(&content[..]);
-                        current_contacts = decoder.decode().next().unwrap().unwrap();
+                        let c = decoder.decode().next();
+                        if !c.is_some() {
+                            let _ = writeln!(&mut io::stderr(), "WARNING: bootstrap file is corrupt! Ignoring.");
+                            ()
+                        }
+                        current_contacts = c.unwrap().unwrap();
                     }
 
                     for i in 0..contacts.len() {
@@ -272,7 +278,7 @@ impl BootStrapHandler {
                     let result = create_file.sync_all();
                     assert!(result.is_ok());
                 },
-                _ => panic!("Could not create file"),
+                _ => panic!("Could not create bootstrap file"),
             }
         }
     }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -278,7 +278,7 @@ impl BootStrapHandler {
                     let result = create_file.sync_all();
                     assert!(result.is_ok());
                 },
-                _ => panic!("Could not create bootstrap file"),
+                _ => panic!("Could not create bootstrap file at {}", self.file_name),
             }
         }
     }

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -24,7 +24,10 @@ use std::thread;
 
 use beacon;
 use bootstrap::{BootStrapHandler, BootStrapContacts, Contact, PublicKey};
-use getifaddrs::getifaddrs;
+#[cfg(any(target_os="linux", target_os="macos"))]
+use getifaddrs_posix::getifaddrs;
+#[cfg(target_os="windows")]
+use getifaddrs_win::getifaddrs;
 use transport;
 use transport::{Endpoint, Port};
 

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -15,21 +15,16 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use cbor;
 use sodiumoxide::crypto::asymmetricbox;
 use std::collections::{HashMap, HashSet};
 use std::io;
 use std::sync::{Arc, mpsc, Mutex, Weak};
 use std::thread;
-use std::mem;
-use libc::consts::os::bsd44::{AF_INET, AF_INET6};
-use libc::funcs::bsd43::getifaddrs as posix_getifaddrs;
-use libc::funcs::bsd43::freeifaddrs as posix_freeifaddrs;
-use libc::types::os::common::bsd44::ifaddrs as posix_ifaddrs;
 
 use beacon;
 use bootstrap::{BootStrapHandler, BootStrapContacts, Contact, PublicKey};
+use getifaddrs::getifaddrs;
 use transport;
 use transport::{Endpoint, Port};
 
@@ -487,77 +482,6 @@ fn start_writing_thread(state: WeakState,
     });
 }
 
-/// Details about an interface on this host
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub struct IfAddr {
-    /// The name of the interface
-    pub name: String,
-    /// The IP address of the interface
-    pub addr: IpAddr,
-    /// The netmask of the interface
-    pub netmask: IpAddr,
-    /// How to send a broadcast on the interface
-    pub broadcast: IpAddr,
-}
-
-impl IfAddr {
-    /// Create a new IfAddr
-    pub fn new() -> IfAddr {
-        IfAddr {
-            name: String::new(),
-            addr: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-            netmask: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
-            broadcast: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))
-        }
-    }
-}
-
-/// Return a vector of IP details for all the valid interfaces on this host
-#[allow(unsafe_code)]
-pub fn getifaddrs() -> Vec<IfAddr> {
-    let mut ret = Vec::<IfAddr>::new();
-    unsafe {
-      let mut ifaddrs : *mut posix_ifaddrs = mem::uninitialized();
-      if -1 == posix_getifaddrs(&mut ifaddrs) {
-        panic!("failed to retrieve interface details from getifaddrs()");
-      }
-      let mut ifaddr = ifaddrs;
-      while !ifaddr.is_null() {
-          if (*ifaddr).ifa_addr.is_null() {
-              continue;
-          }
-          let mut item = IfAddr::new();
-          // TODO name
-          let sockaddr = *(*ifaddr).ifa_addr;
-          if sockaddr.sa_family == AF_INET as u16 {
-              item.addr=IpAddr::V4(Ipv4Addr::new(
-                  sockaddr.sa_data[0],
-                  sockaddr.sa_data[1],
-                  sockaddr.sa_data[2],
-                  sockaddr.sa_data[3],
-              ));
-          } else if sockaddr.sa_family == AF_INET6 as u16 {
-              item.addr=IpAddr::V6(Ipv6Addr::new(
-                  sockaddr.sa_data[0] as u16  | ((sockaddr.sa_data[1] as u16) << 8),
-                  sockaddr.sa_data[2] as u16  | ((sockaddr.sa_data[3] as u16) << 8),
-                  sockaddr.sa_data[4] as u16  | ((sockaddr.sa_data[5] as u16) << 8),
-                  sockaddr.sa_data[6] as u16  | ((sockaddr.sa_data[7] as u16) << 8),
-                  sockaddr.sa_data[8] as u16  | ((sockaddr.sa_data[9] as u16) << 8),
-                  sockaddr.sa_data[10] as u16 | ((sockaddr.sa_data[11] as u16) << 8),
-                  sockaddr.sa_data[12] as u16 | ((sockaddr.sa_data[13] as u16) << 8),
-                  sockaddr.sa_data[14] as u16 | ((sockaddr.sa_data[15] as u16) << 8),
-              ));
-          }
-          // TODO netmask
-          // TODO broadcast
-          // TODO FIXME UNIT TEST
-          ret.push(item);
-          ifaddr = (*ifaddr).ifa_next;
-      }
-      posix_freeifaddrs(ifaddrs);
-    }
-    ret
-}
 
 #[cfg(test)]
 mod test {

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -24,10 +24,7 @@ use std::thread;
 
 use beacon;
 use bootstrap::{BootStrapHandler, BootStrapContacts, Contact, PublicKey};
-#[cfg(any(target_os="linux", target_os="macos"))]
-use getifaddrs_posix::getifaddrs;
-#[cfg(target_os="windows")]
-use getifaddrs_win::getifaddrs;
+use getifaddrs::getifaddrs;
 use transport;
 use transport::{Endpoint, Port};
 

--- a/src/getifaddrs.rs
+++ b/src/getifaddrs.rs
@@ -70,7 +70,7 @@ mod getifaddrs_posix {
         } else if unsafe{*sockaddr}.sa_family as u32 == AF_INET6 as u32 {
             let ref sa = unsafe{*(sockaddr as *const posix_sockaddr_in6)};
             // Ignore all fe80:: addresses as these are link locals
-            if sa.sin6_addr.s6_addr[0]==0x80fe { None }
+            if sa.sin6_addr.s6_addr[0]==0x80fe { return None }
             Some(IpAddr::V6(Ipv6Addr::new(
                 ((sa.sin6_addr.s6_addr[0] & 255)<<8) | ((sa.sin6_addr.s6_addr[0]>>8) & 255),
                 ((sa.sin6_addr.s6_addr[1] & 255)<<8) | ((sa.sin6_addr.s6_addr[1]>>8) & 255),

--- a/src/getifaddrs.rs
+++ b/src/getifaddrs.rs
@@ -1,0 +1,134 @@
+// Copyright 2015 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::{mem, str};
+use std::ffi::CStr;
+use libc::consts::os::bsd44::{AF_INET, AF_INET6};
+use libc::funcs::bsd43::getifaddrs as posix_getifaddrs;
+use libc::funcs::bsd43::freeifaddrs as posix_freeifaddrs;
+use libc::types::os::common::bsd44::ifaddrs as posix_ifaddrs;
+use libc::types::os::common::bsd44::sockaddr as posix_sockaddr;
+
+/// Details about an interface on this host
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct IfAddr {
+    /// The name of the interface
+    pub name: String,
+    /// The IP address of the interface
+    pub addr: IpAddr,
+    /// The netmask of the interface
+    pub netmask: IpAddr,
+    /// How to send a broadcast on the interface
+    pub broadcast: IpAddr,
+}
+
+impl IfAddr {
+    /// Create a new IfAddr
+    pub fn new() -> IfAddr {
+        IfAddr {
+            name: String::new(),
+            addr: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            netmask: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)),
+            broadcast: IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0))
+        }
+    }
+}
+
+/// Return a vector of IP details for all the valid interfaces on this host
+#[allow(unsafe_code)]
+pub fn getifaddrs() -> Vec<IfAddr> {
+    let mut ret = Vec::<IfAddr>::new();
+    unsafe {
+      let mut ifaddrs : *mut posix_ifaddrs = mem::uninitialized();
+      if -1 == posix_getifaddrs(&mut ifaddrs) {
+        panic!("failed to retrieve interface details from getifaddrs()");
+      }
+      let sockaddr_to_ipaddr = |sockaddr : posix_sockaddr| -> Option<IpAddr> {
+          if sockaddr.sa_family == AF_INET as u16 {
+              Some(IpAddr::V4(Ipv4Addr::new(
+                  sockaddr.sa_data[0],
+                  sockaddr.sa_data[1],
+                  sockaddr.sa_data[2],
+                  sockaddr.sa_data[3],
+              )))
+          } else if sockaddr.sa_family == AF_INET6 as u16 {
+              Some(IpAddr::V6(Ipv6Addr::new(
+                  sockaddr.sa_data[0] as u16  | ((sockaddr.sa_data[1] as u16) << 8),
+                  sockaddr.sa_data[2] as u16  | ((sockaddr.sa_data[3] as u16) << 8),
+                  sockaddr.sa_data[4] as u16  | ((sockaddr.sa_data[5] as u16) << 8),
+                  sockaddr.sa_data[6] as u16  | ((sockaddr.sa_data[7] as u16) << 8),
+                  sockaddr.sa_data[8] as u16  | ((sockaddr.sa_data[9] as u16) << 8),
+                  sockaddr.sa_data[10] as u16 | ((sockaddr.sa_data[11] as u16) << 8),
+                  sockaddr.sa_data[12] as u16 | ((sockaddr.sa_data[13] as u16) << 8),
+                  sockaddr.sa_data[14] as u16 | ((sockaddr.sa_data[15] as u16) << 8),
+              )))
+          }
+          else { None }
+      };
+          
+      let mut ifaddr = ifaddrs;
+      while !ifaddr.is_null() {
+          if (*ifaddr).ifa_addr.is_null() {
+              continue;
+          }
+          let mut item = IfAddr::new();
+          let name = CStr::from_ptr((*ifaddr).ifa_name).to_bytes();
+          item.name = str::from_utf8(name).unwrap().to_owned();
+          match sockaddr_to_ipaddr(*(*ifaddr).ifa_addr) {
+              Some(a) => item.addr = a,
+              None => continue,
+          };
+          match sockaddr_to_ipaddr(*(*ifaddr).ifa_netmask) {
+              Some(a) => item.netmask = a,
+              None => continue,
+          };
+          if ((*ifaddr).ifa_flags & 2 /*IFF_BROADCAST*/) != 0 {
+              match sockaddr_to_ipaddr(*(*ifaddr).ifa_ifu) {
+                  Some(a) => item.broadcast = a,
+                  None => continue,
+              };
+          }
+          ret.push(item);
+          ifaddr = (*ifaddr).ifa_next;
+      }
+      posix_freeifaddrs(ifaddrs);
+    }
+    ret
+}
+
+#[cfg(test)]
+mod test {
+    use super::getifaddrs;
+    use std::net::IpAddr;
+    
+    #[test]
+    fn test_getifaddrs() {
+        let mut has_loopback4 = false;
+        let mut has_loopback6 = false;
+        for ifaddr in getifaddrs() {
+            println!("Interface {} has IP {} netmask {} broadcast {}", ifaddr.name,
+                     ifaddr.addr, ifaddr.netmask, ifaddr.broadcast);
+            match ifaddr.addr {
+                IpAddr::V4(v4) => if v4.is_loopback() { has_loopback4=true; },
+                IpAddr::V6(v6) => if v6.is_loopback() { has_loopback6=true; },
+            }
+        }
+        // Quick sanity test, can't think of anything better
+        assert_eq!(has_loopback4 || has_loopback6, true);
+    }
+}

--- a/src/getifaddrs.rs
+++ b/src/getifaddrs.rs
@@ -75,14 +75,14 @@ pub fn getifaddrs() -> Vec<IfAddr> {
         } else if unsafe{*sockaddr}.sa_family == AF_INET6 as u16 {
             let ref sa = unsafe{*(sockaddr as *const posix_sockaddr_in6)};
             Some(IpAddr::V6(Ipv6Addr::new(
-                sa.sin6_addr.s6_addr[0],
-                sa.sin6_addr.s6_addr[1],
-                sa.sin6_addr.s6_addr[2],
-                sa.sin6_addr.s6_addr[3],
-                sa.sin6_addr.s6_addr[4],
-                sa.sin6_addr.s6_addr[5],
-                sa.sin6_addr.s6_addr[6],
-                sa.sin6_addr.s6_addr[7],
+                ((sa.sin6_addr.s6_addr[0] & 255)<<8) | ((sa.sin6_addr.s6_addr[0]>>8) & 255),
+                ((sa.sin6_addr.s6_addr[1] & 255)<<8) | ((sa.sin6_addr.s6_addr[1]>>8) & 255),
+                ((sa.sin6_addr.s6_addr[2] & 255)<<8) | ((sa.sin6_addr.s6_addr[2]>>8) & 255),
+                ((sa.sin6_addr.s6_addr[3] & 255)<<8) | ((sa.sin6_addr.s6_addr[3]>>8) & 255),
+                ((sa.sin6_addr.s6_addr[4] & 255)<<8) | ((sa.sin6_addr.s6_addr[4]>>8) & 255),
+                ((sa.sin6_addr.s6_addr[5] & 255)<<8) | ((sa.sin6_addr.s6_addr[5]>>8) & 255),
+                ((sa.sin6_addr.s6_addr[6] & 255)<<8) | ((sa.sin6_addr.s6_addr[6]>>8) & 255),
+                ((sa.sin6_addr.s6_addr[7] & 255)<<8) | ((sa.sin6_addr.s6_addr[7]>>8) & 255),
             )))
         }
         else { None }
@@ -132,7 +132,7 @@ mod test {
         let mut has_loopback4 = false;
         let mut has_loopback6 = false;
         for ifaddr in getifaddrs() {
-            println!("Interface {} has IP {} netmask {} broadcast {}", ifaddr.name,
+            println!("   Interface {} has IP {} netmask {} broadcast {}", ifaddr.name,
                      ifaddr.addr, ifaddr.netmask, ifaddr.broadcast);
             match ifaddr.addr {
                 IpAddr::V4(v4) => if v4.is_loopback() { has_loopback4=true; },

--- a/src/getifaddrs.rs
+++ b/src/getifaddrs.rs
@@ -110,13 +110,11 @@ pub fn getifaddrs() -> Vec<IfAddr> {
             Some(a) => item.netmask = a,
             None => (),
         };
-        if cfg!(target_os = "linux") {
-            if (ifaddr.ifa_flags & 2 /*IFF_BROADCAST*/) != 0 {
-                match sockaddr_to_ipaddr(ifaddr.ifa_ifu) {
-                    Some(a) => item.broadcast = a,
-                    None => (),
-                };
-            }
+        if (ifaddr.ifa_flags & 2 /*IFF_BROADCAST*/) != 0 {
+            match sockaddr_to_ipaddr(ifaddr.ifa_ifu) {
+                Some(a) => item.broadcast = a,
+                None => (),
+            };
         }
         ret.push(item);
     }

--- a/src/getifaddrs_posix.rs
+++ b/src/getifaddrs_posix.rs
@@ -110,11 +110,13 @@ pub fn getifaddrs() -> Vec<IfAddr> {
             Some(a) => item.netmask = a,
             None => (),
         };
-        if (ifaddr.ifa_flags & 2 /*IFF_BROADCAST*/) != 0 {
-            match sockaddr_to_ipaddr(ifaddr.ifa_ifu) {
-                Some(a) => item.broadcast = a,
-                None => (),
-            };
+        if cfg!(target_os = "linux") {
+            if (ifaddr.ifa_flags & 2 /*IFF_BROADCAST*/) != 0 {
+                match sockaddr_to_ipaddr(ifaddr.ifa_ifu) {
+                    Some(a) => item.broadcast = a,
+                    None => (),
+                };
+            }
         }
         ret.push(item);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,10 @@ mod test {
 }
 mod beacon;
 mod bootstrap;
-mod getifaddrs;
+#[cfg(any(target_os="linux", target_os="macos"))]
+mod getifaddrs_posix;
+#[cfg(target_os="windows")]
+mod getifaddrs_win;
 mod tcp_connections;
 mod transport;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,22 @@ extern crate time;
 extern crate asynchronous;
 extern crate libc;
 
+#[cfg(test)]
+mod test {
+    use std::env;
+    
+    #[test]
+    pub fn check_rust_unit_testing_is_not_parallel() {
+        match env::var_os("RUST_TEST_THREADS") {
+            Some(val) => assert!(val.into_string().unwrap() == "1"),
+            None => panic!("RUST_TEST_THREADS and RUST_TEST_TASKS needs to be 1 for the crust unit tests to work"),
+        }
+        match env::var_os("RUST_TEST_TASKS") {
+            Some(val) => assert!(val.into_string().unwrap() == "1"),
+            None => panic!("RUST_TEST_THREADS and RUST_TEST_TASKS needs to be 1 for the crust unit tests to work"),
+        }
+    }
+}
 mod beacon;
 mod bootstrap;
 mod getifaddrs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,10 +58,7 @@ mod test {
 }
 mod beacon;
 mod bootstrap;
-#[cfg(any(target_os="linux", target_os="macos"))]
-mod getifaddrs_posix;
-#[cfg(target_os="windows")]
-mod getifaddrs_win;
+mod getifaddrs;
 mod tcp_connections;
 mod transport;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ extern crate libc;
 
 mod beacon;
 mod bootstrap;
+mod getifaddrs;
 mod tcp_connections;
 mod transport;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ extern crate rustc_serialize;
 extern crate sodiumoxide;
 extern crate time;
 extern crate asynchronous;
+extern crate libc;
 
 mod beacon;
 mod bootstrap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,8 @@
 //! Reliable p2p network connections in Rust with NAT traversal.
 //! One of the most needed libraries for any server-less / decentralised projects
 
-#![forbid(bad_style, missing_docs, warnings)]
-#![deny(deprecated, drop_with_repr_extern, improper_ctypes, non_shorthand_field_patterns,
+#![forbid(missing_docs, warnings)]
+#![deny(bad_style, deprecated, drop_with_repr_extern, improper_ctypes, non_shorthand_field_patterns,
         overflowing_literals, plugin_as_library, private_no_mangle_fns, private_no_mangle_statics,
         raw_pointer_derive, stable_features, unconditional_recursion, unknown_lints,
         unsafe_code, unsigned_negation, unused, unused_allocation, unused_attributes,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,9 +30,8 @@
 #![doc(html_logo_url = "http://maidsafe.net/img/Resources/branding/maidsafe_logo.fab2.png",
        html_favicon_url = "http://maidsafe.net/img/favicon.ico",
        html_root_url = "http:///dirvine.github.io/crust/crust/")]
-#![feature(ip_addr, ip, lookup_host, alloc, udp, scoped)]
+#![feature(ip_addr, ip, alloc, udp, scoped)]
 
-extern crate libc;
 extern crate cbor;
 extern crate rand;
 extern crate rustc_serialize;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -46,8 +46,9 @@ impl Endpoint {
     /// Creates a Tcp(SocketAddr)
     pub fn tcp<A: ToSocketAddrs>(addr: A) -> Endpoint {
         match addr.to_socket_addrs().unwrap().next() {
-            Some(a) => Endpoint::Tcp(a)
-        };
+            Some(a) => Endpoint::Tcp(a),
+            None => panic!("Failed to parse valid IP address"),
+        }
     }
     /// Returns SocketAddr.
     pub fn get_address(&self) -> SocketAddr {
@@ -154,7 +155,7 @@ pub enum Acceptor {
 impl Acceptor {
     pub fn local_port(&self) -> Port {
         match *self {
-            Acceptor::Tcp(_, listener) => Port::Tcp(listener.local_addr().unwrap().port()),
+            Acceptor::Tcp(_, ref listener) => Port::Tcp(listener.local_addr().unwrap().port()),
         }
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -15,9 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use libc;
-use std::net;
-use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6, TcpStream, TcpListener};
+use std::net::{SocketAddr, TcpStream, TcpListener, ToSocketAddrs};
 use tcp_connections;
 use std::io;
 use std::io::Result as IoResult;
@@ -45,6 +43,12 @@ pub enum Endpoint {
 }
 
 impl Endpoint {
+    /// Creates a Tcp(SocketAddr)
+    pub fn tcp<A: ToSocketAddrs>(addr: A) -> Endpoint {
+        match addr.to_socket_addrs().unwrap().next() {
+            Some(a) => Endpoint::Tcp(a)
+        };
+    }
     /// Returns SocketAddr.
     pub fn get_address(&self) -> SocketAddr {
         match *self {
@@ -71,10 +75,19 @@ impl Decodable for Endpoint {
 }
 
 /// Enum representing port of supported protocols
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Port {
     /// TCP port
     Tcp(u16),
+}
+
+impl Port {
+    /// Return the port
+    pub fn get_port(&self) -> u16 {
+        match *self {
+            Port::Tcp(p) => p,
+        }
+    }
 }
 
 impl PartialOrd for Endpoint {
@@ -134,14 +147,14 @@ impl Receiver {
 
 //--------------------------------------------------------------------
 pub enum Acceptor {
-    // Channel receiver, TCP listener and calculated local TCP endpoint
-    Tcp(mpsc::Receiver<(TcpStream, SocketAddr)>, TcpListener, SocketAddr),
+    // Channel receiver, TCP listener
+    Tcp(mpsc::Receiver<(TcpStream, SocketAddr)>, TcpListener),
 }
 
 impl Acceptor {
-    pub fn local_endpoint(&self) -> Endpoint {
+    pub fn local_port(&self) -> Port {
         match *self {
-            Acceptor::Tcp(_, _, local_address) => Endpoint::Tcp(local_address),
+            Acceptor::Tcp(_, listener) => Port::Tcp(listener.local_addr().unwrap().port()),
         }
     }
 }
@@ -173,17 +186,7 @@ pub fn new_acceptor(port: &Port) -> IoResult<Acceptor> {
     match *port {
         Port::Tcp(ref port) => {
             let (receiver, listener) = try!(tcp_connections::listen(*port));
-            // If we fail to calculate local address, fall back to listener.local_addr().
-            let local_address =
-                if let Ok(address) = get_tcp_listener_local_address(&listener) {
-                    address
-                } else {
-                    try!(listener.local_addr())
-                };
-            // Discard the first connection since this is caused by calling
-            // `get_tcp_listener_local_address` above.
-            let _ = receiver.recv();
-            Ok(Acceptor::Tcp(receiver, listener, local_address))
+            Ok(Acceptor::Tcp(receiver, listener))
         }
     }
 }
@@ -192,7 +195,7 @@ pub fn new_acceptor(port: &Port) -> IoResult<Acceptor> {
 // (Though this seems to be impossible with the current Rust TCP API).
 pub fn accept(acceptor: &Acceptor) -> IoResult<Transport> {
     match *acceptor {
-        Acceptor::Tcp(ref rx_channel, _, _) => {
+        Acceptor::Tcp(ref rx_channel, _) => {
             let (stream, remote_endpoint) = try!(rx_channel.recv()
                 .map_err(|e| io::Error::new(io::ErrorKind::NotConnected, e.description())));
 
@@ -204,82 +207,6 @@ pub fn accept(acceptor: &Acceptor) -> IoResult<Transport> {
                         })
         }
     }
-}
-
-extern {
-    pub fn gethostname(name: *mut libc::c_char, size: libc::size_t) -> libc::c_int;
-}
-
-#[allow(unsafe_code)]
-fn get_hostname() -> IoResult<String> {
-    let length = 1000usize;
-    let mut buffer = vec![0u8; length];
-    let result = unsafe {
-        gethostname(buffer.as_mut_ptr() as *mut libc::c_char, length as libc::size_t)
-    };
-    if result != 0 {
-        return Err(io::Error::new(io::ErrorKind::Other,
-            format!("Failed to get hostname: returned {}", result)));
-    }
-
-    // Find the first 0 byte (i.e. just after the data that gethostname wrote).
-    let actual_length = buffer.iter().position(|byte| *byte == 0).unwrap_or(length);
-
-    // Trim the hostname to the actual data written and return the resultant String.
-    buffer.truncate(actual_length);
-    String::from_utf8(buffer).map_err(|error| io::Error::new(io::ErrorKind::Other,
-                                                             format!("{}", error)))
-}
-
-// It would be easiest to just return listener.local_addr() here, but this yields an IP of 0.0.0.0,
-// which is not useful for passing to peers on a different machine.  Hence we try and connect to the
-// listener via each of the local host interfaces to establish its actual IP address.  Once one is
-// connected, the stream's local_addr() or peer_addr() yields the actual local address.
-//
-// TODO - This isn't robust: we're not checking that the listener we connect to is
-// actually the one we just created - we should maybe send a magic request and response
-// to confirm this.
-fn get_tcp_listener_local_address(listener: &TcpListener) -> IoResult<SocketAddr> {
-    let listener_local_address = try!(listener.local_addr());
-    let listener_port = listener_local_address.port();
-    let listener_is_v4 = match listener_local_address {
-        SocketAddr::V4(_) => true,
-        SocketAddr::V6(_) => false,
-    };
-
-    let host = try!(get_hostname());
-    let host_interface_itr = try!(net::lookup_host(&host));
-
-    // Iterate each interface and try to connect.  Once/if connected, the peer_addr yields the
-    // local address.
-    for host_interface in host_interface_itr {
-        let attempt_address = match host_interface {
-            Ok(SocketAddr::V4(address)) => {
-                if !listener_is_v4 {
-                    continue;
-                }
-                SocketAddr::V4(SocketAddrV4::new(*address.ip(), listener_port))
-            },
-            Ok(SocketAddr::V6(address)) => {
-                if listener_is_v4 {
-                    continue;
-                }
-                SocketAddr::V6(SocketAddrV6::new(*address.ip(), listener_port,
-                                                 address.flowinfo(), address.scope_id()))
-            },
-            _ => continue,
-        };
-        match TcpStream::connect(attempt_address) {
-            Ok(stream) => {
-                match stream.peer_addr() {
-                    Ok(peer_address) => return Ok(peer_address),
-                    Err(_) => (),
-                }
-            },
-            _ => (),
-        };
-    }
-    Err(io::Error::new(io::ErrorKind::AddrNotAvailable, "Failed to get local address"))
 }
 
 fn compare_ip_addrs(a1: &SocketAddr, a2: &SocketAddr) -> Ordering {


### PR DESCRIPTION
I'll need to keep adding debug printing until I figure out what's going wrong here. So far it looks like somewhere I'm failing to set a port number, and therefore bootstrapping is done to the wrong location.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/121)
<!-- Reviewable:end -->
