### PR TITLE
Minor fix to allow example to run in debug mode and renamed the example to crust_peer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ test = true
 bench = false
 
 [[example]]
-name = "crust_node"
-path = "examples/crust_node.rs"
+name = "crust_peer"
+path = "examples/crust_peer.rs"
 test = true
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "crust"
-version = "0.0.9"
+version = "0.0.10"
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "p2p networking library. Automatically reconnect and manage connections."
 documentation = "http://maidsafe.github.io/crust/crust"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Several methods are used for NAT traversal, UpNP, hole punching [See here for TC
 
 ## [0.0.9]
 - [x] [MAID-1075](https://maidsafe.atlassian.net/browse/MAID-1075) Correct bug; listening on local port (127.0.0.1)
+
+## [0.0.10]
 - [ ] Have ConnectionManager guarantee at most one connection between any two nodes
 - [ ] Utp Networking
   - [ ] Utp live port and backup random port selection

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ _direct connected == Nodes we were previously connected to. TCP nodes or reliabl
 Several methods are used for NAT traversal, UpNP, hole punching [See here for TCP NAT traversal] (http://www.cmlab.csie.ntu.edu.tw/~franklai/NATBT.pdf) and [here for UCP/DHT NAT traversal
   ](http://maidsafe.net/Whitepapers/pdf/DHTbasedNATTraversal.pdf) etc. These methods will be added to by the community to allow a p2p network that cannot be easily blocked. By default this library spawns sockets randomly, enabling nodes to appear on several ports over time. This makes them very difficult to trace.
 
+###Pre-requisite:
+libsodium is a native dependency for [sodiumxoide](https://github.com/dnaq/sodiumoxide). Thus, install sodium by following the instructions [here](http://doc.libsodium.org/installation/index.html).
+
+For windows, download and use the [prebuilt mingw library](https://download.libsodium.org/libsodium/releases/libsodium-1.0.2-mingw.tar.gz).
+Extract and place the libsodium.a file in "bin\x86_64-pc-windows-gnu" for 64bit System, or "bin\i686-pc-windows-gnu" for a 32bit system.
 
 ##Todo Items
 

--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -44,13 +44,13 @@ use crust::{ConnectionManager, Endpoint, Port};
 
 static USAGE: &'static str = "
 Usage:
-  crust_node [options] [<peer>...]
+  crust_peer [options] [<peer>...]
 
-The node will try and bootstrap off one of the peers if any are provided.  If
-none are provided, or if connecting to any of the peers fails, the UDP beacon
-will be used.  If no beacon port is specified in the options, then port 9999
-will be chosen.  If no listening port is supplied, a random port for each
-supported protocol will be chosen.
+The crust peer will try and bootstrap off one of the peers if any are provided.
+If none are provided, or if connecting to any of the peers fails, the UDP beacon
+will be used. If no beacon port is specified in the options, then port 9999 will
+be chosen. If no listening port is supplied, a random port for each supported
+protocol will be chosen.
 
 Options:
   -t PORT, --tcp-port=PORT  Start listening on the specified TCP port.

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -310,9 +310,9 @@ impl ConnectionManager {
     }
 
     fn bootstrap_off_list(&self, bootstrap_list: Vec<Endpoint>) -> io::Result<Endpoint> {
-        if bootstrap_list.is_empty() {
-            panic!("The bootstrap list is empty, therefore cannot bootstrap");
-        }
+        // if bootstrap_list.is_empty() {
+        //     panic!("The bootstrap list is empty, therefore cannot bootstrap");
+        // }
         let mut vec_deferred = vec![];
         for endpoint in bootstrap_list {
             let state_cloned = self.state.clone();
@@ -331,10 +331,10 @@ impl ConnectionManager {
         }
         let res = Deferred::first_to_promise(1,false,vec_deferred, ControlFlow::ParallelLimit(15)).sync();
         match res {
-            Ok(v) => if v.len() > 0 { return Ok(v[0].clone()) },            
+            Ok(v) => if v.len() > 0 { return Ok(v[0].clone()) },
             Err(_) => (),
         }
-        // FIXME: The result should probably be Option<Endpoint> 
+        // FIXME: The result should probably be Option<Endpoint>
         Err(io::Error::new(io::ErrorKind::Other, "No bootstrap node got connected"))
     }
 
@@ -776,7 +776,7 @@ mod test {
 #[test]
     fn connection_manager_start() {
         // Wait 2 seconds until previous bootstrap test ends. If not, that test connects to these endpoints.
-        thread::sleep_ms(2000);        
+        thread::sleep_ms(2000);
         let (cm_tx, cm_rx) = channel();
         let mut cm = ConnectionManager::new(cm_tx);
         let cm_listen_ports = match cm.start_listening(vec![Port::Tcp(4455)], Some(5483)) {


### PR DESCRIPTION
Commented out a panic which will terminate crust example (first node) in debug mode.
Renamed example to crust_peer.
Updated readme to include libsodium pre-requisite.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/124)
<!-- Reviewable:end -->
