### PR TITLE
Removed unneccessary check for `RUST_TEST_TASKS` env var.  This varia…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,16 +43,12 @@ extern crate libc;
 #[cfg(test)]
 mod test {
     use std::env;
-    
+
     #[test]
     pub fn check_rust_unit_testing_is_not_parallel() {
         match env::var_os("RUST_TEST_THREADS") {
             Some(val) => assert!(val.into_string().unwrap() == "1"),
-            None => panic!("RUST_TEST_THREADS and RUST_TEST_TASKS needs to be 1 for the crust unit tests to work"),
-        }
-        match env::var_os("RUST_TEST_TASKS") {
-            Some(val) => assert!(val.into_string().unwrap() == "1"),
-            None => panic!("RUST_TEST_THREADS and RUST_TEST_TASKS needs to be 1 for the crust unit tests to work"),
+            None => panic!("RUST_TEST_THREADS needs to be 1 for the crust unit tests to work"),
         }
     }
 }


### PR DESCRIPTION
…ble was replaced in https://github.com/rust-lang/rust/pull/23525

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/126)
<!-- Reviewable:end -->
