### PR TITLE
Fix for first node doesn't read its own bootstrap list

### DIFF
--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,0 +1,29 @@
+### Bootstrap Cache
+Bootstrap cache file (JSON file) can be used to pass a few configuration information along with cache of previous connections and fall back endpoints information to Crust node.
+
+It needs to be present in the current executable directory. It name needs to be of the format :
+`<current executable>.bootstrap.cache `
+For crust_peer example, the bootstrap_file will be `crust_peer.bootstrap.cache`
+
+File has following fields:
+1. `preferred_port`: Crust node will try to start listening on this port on mentioned protocol variant (if supported). If the port is already aquired by some other process, then a random port is chosen.
+2.  `hard_coded_contacts`: List of hardcoded endpoints. Crust when bootstrapping, will read and append these hardcoded endpoints to the acquired bootstrap endpoints by default methods (beacon & contacts field from bootstrap file). The hardcoded endpoints are to cater for fallback situations when a node can not connect to any other node using default methods.
+3.  `contacts`: List of endpoints which is used (in addition to other default methods) when a crust node attempts to bootstrap off a network. This list is updated by the owner of the bootstrap file whenever it gets a new connection.
+
+*Example of bootstrap cache file:*
+```
+{"preferred_port":{"variant":"Tcp","fields":[0]},"hard_coded_contacts":[{"endpoint":"192.168.0.10:51296"},{"endpoint":"192.168.0.10:5455"}],"contacts":[{"endpoint":"127.0.0.1:51296"},{"endpoint":"192.168.0.10:51296"},{"endpoint":"192.168.0.10:57545"}]}
+```
+
+**Starting a node on a specific port** (useful if the machine’s IP is publicly available)
+Update preferred_port to desired port and protocol variant (only TCP supported currently).
+Example:  ``` "preferred_port":{"variant":"Tcp","fields":[5555]} ```
+
+**Adding hardcoded endpoints to a bootstrap file** (bootstrap file should be packaged into the installer with only hard_coded_contacts field populated and keeping other fields empty)
+
+```
+"hard_coded_contacts":[{"endpoint":"192.168.0.10:51296"},{"endpoint":"192.168.0.10:5455"}],
+```
+
+**API change notes**
+The API is preserved as previous version (0.0.62). ConnectionManager::start_listening2()  takes listening port as hint. This will work the same way and will override the preferred_port read from bootstrap file. So upper layers now need to start using the bootstrap file to pass hint field.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -16,6 +16,8 @@ File has following fields:
 ```
 
 **Starting a node on a specific port** (useful if the machine’s IP is publicly available)
+Also useful and required for users who want to port forward their router (i.e. run tcp node at home). It is less safe though as you will always connect to the network on the same ports, but this is potentially a very small security issue and not of concern to many.
+
 Update preferred_port to desired port and protocol variant (only TCP supported currently).
 Example:  ``` "preferred_port":{"variant":"Tcp","fields":[5555]} ```
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -1,7 +1,7 @@
 ### Bootstrap Cache
 Bootstrap cache file (JSON file) can be used to pass a few configuration information along with cache of previous connections and fall back endpoints information to Crust node.
 
-It needs to be present in the current executable directory. It name needs to be of the format :
+It needs to be present in the directory the exe is run from (work dir). It name needs to be of the format :
 `<current executable>.bootstrap.cache `
 For crust_peer example, the bootstrap_file will be `crust_peer.bootstrap.cache`
 

--- a/src/bootstrap_handler.rs
+++ b/src/bootstrap_handler.rs
@@ -36,9 +36,9 @@ pub type Contacts = Vec<Contact>;
 
 #[derive(PartialEq, Debug, RustcDecodable, RustcEncodable)]
 pub struct BootStrap {
-    preferred_port: Port,
-    hard_coded_contacts: Contacts,
-    contacts: Contacts,
+    pub preferred_port: Port,
+    pub hard_coded_contacts: Contacts,
+    pub contacts: Contacts,
 }
 
 pub struct BootStrapHandler {
@@ -108,7 +108,7 @@ impl BootStrapHandler {
         Ok(())
     }
 
-    fn read_bootstrap_file(&self) -> io::Result<(BootStrap)> {
+    pub fn read_bootstrap_file(&self) -> io::Result<(BootStrap)> {
         let mut file = try!(File::open(&self.file_name));
         let mut s = String::new();
         let _ = try!(file.read_to_string(&mut s));

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -196,6 +196,31 @@ impl ConnectionManager {
         Ok((endpoints, ports_and_beacon.1))
     }
 
+
+    // NOTE this can be reused at other places.
+    fn get_listening_endpoint(&self) -> io::Result<(Vec<Endpoint>)> {
+        let ws = self.state.downgrade();
+        let listening_ports = try!(lock_state(&ws, |s| {
+            let buf: Vec<Port> = s.listening_ports.iter().map(|s| s.clone()).collect();
+            Ok(buf)
+        }));
+
+        let mut endpoints = Vec::<Endpoint>::new();
+        for port in listening_ports {
+            match port {
+                Port::Tcp(p) => {
+                    for ifaddr in getifaddrs() {
+                        endpoints.push(match ifaddr.addr {
+                            IpAddr::V4(a) => Endpoint::tcp((a, p)),
+                            IpAddr::V6(a) => Endpoint::tcp((a, p)),
+                        });
+                    }
+                },
+            }
+        }
+        Ok(endpoints)
+    }
+
     /// This method tries to connect (bootstrap to exisiting network) to the default or provided
     /// list of bootstrap nodes.
     ///
@@ -220,7 +245,24 @@ impl ConnectionManager {
         };
         match bootstrap_list {
             Some(list) => self.bootstrap_off_list(list),
-            None => self.bootstrap_off_list(self.seek_peers(port)),
+            None => {
+                let mut combined_endpoint_list = self.seek_peers(port);
+                if self.beacon_guid_and_port.is_some() {  // this node owns bs file
+                    let handler = BootStrapHandler::new();
+                    match handler.read_bootstrap_file() {
+                        Ok(read_contacts) => {
+                            for contacts in read_contacts.contacts {
+                                combined_endpoint_list.push(contacts.endpoint);
+                            }
+                            for contacts in read_contacts.hard_coded_contacts {
+                                combined_endpoint_list.push(contacts.endpoint);
+                            }
+                        },
+                        _ => {},
+                    }
+                }
+                self.bootstrap_off_list(combined_endpoint_list)
+            },
         }
     }
 
@@ -353,10 +395,11 @@ impl ConnectionManager {
         endpoints
     }
 
-    fn bootstrap_off_list(&self, bootstrap_list: Vec<Endpoint>) -> io::Result<Endpoint> {
-        // if bootstrap_list.is_empty() {
-        //     panic!("The bootstrap list is empty, therefore cannot bootstrap");
-        // }
+    fn bootstrap_off_list(&self, mut bootstrap_list: Vec<Endpoint>) -> io::Result<Endpoint> {
+        // remove own endpoints
+        let own_listening_endpoint = try!(self.get_listening_endpoint());
+        bootstrap_list.retain(|x| !own_listening_endpoint.contains(&x));
+
         let mut vec_deferred = vec![];
         for endpoint in bootstrap_list {
             let state_cloned = self.state.clone();


### PR DESCRIPTION
Also added a crude fix not bootstrapping off own listening ports by removing own listening endpoints just before bootstrapping.  Fixes  #134 

I will do a separate PR to clean up.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/135)
<!-- Reviewable:end -->
