### PR TITLE
fix build failures with rust nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 #![doc(html_logo_url = "http://maidsafe.net/img/Resources/branding/maidsafe_logo.fab2.png",
        html_favicon_url = "http://maidsafe.net/img/favicon.ico",
        html_root_url = "http:///dirvine.github.io/crust/crust/")]
-#![feature(ip_addr, ip, alloc, udp, scoped)]
+#![feature(ip_addr, ip, udp, arc_weak)]
 
 extern crate cbor;
 extern crate rand;


### PR DESCRIPTION
The build failures comes mainly due to deprecation of thread::scoped.

Fixes #149

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/151)
<!-- Reviewable:end -->
