### PR TITLE
fix: now it's safe to call ConnectionManager::stop twice

### DIFF
--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -269,9 +269,10 @@ impl ConnectionManager {
 
     /// This should be called before destroying an instance of a ConnectionManager to allow the
     /// listener threads to join.  Once called, the ConnectionManager should be destroyed.
-    pub fn stop(&self) {
+    pub fn stop(&mut self) {
         if let Some(beacon_guid_and_port) = self.beacon_guid_and_port {
-            beacon::BroadcastAcceptor::stop(&beacon_guid_and_port)
+            beacon::BroadcastAcceptor::stop(&beacon_guid_and_port);
+            self.beacon_guid_and_port = None;
         }
         let mut listening_ports = Vec::<Port>::new();
         let weak_state = self.state.downgrade();


### PR DESCRIPTION
I've had to clean a lot of debugging code before committing the fix, but it's here now.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/157)
<!-- Reviewable:end -->
