### PR TITLE
print self.performance_interval instead of hardcoded 10

### DIFF
--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -216,8 +216,8 @@ impl FlatWorld {
             self.performance_start = time::SteadyTime::now();
         }
         if self.performance_start + self.performance_interval < time::SteadyTime::now() {
-            println!("\nReceived {} messages with total size of {} bytes in last 10 seconds.",
-                     self.received_msgs, self.received_bytes);
+            println!("\nReceived {} messages with total size of {} bytes in last {} seconds.",
+                     self.received_msgs, self.received_bytes, self.performance_interval.num_seconds());
             self.received_msgs = 0;
             self.received_bytes = 0;
         }


### PR DESCRIPTION
It's just minor change to don't confuse the ones who are looking into the example.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/158)

<!-- Reviewable:end -->
