### PR TITLE
cleanup: transport::{Endpoint, Port} derive from Copy

### DIFF
--- a/src/beacon.rs
+++ b/src/beacon.rs
@@ -74,7 +74,7 @@ pub struct BroadcastAcceptor {
 impl BroadcastAcceptor {
     pub fn new(port: u16) -> Result<BroadcastAcceptor> {
         let socket = try!(UdpSocket::bind(("0.0.0.0", port)));
-        let acceptor = try!(transport::new_acceptor(&Port::Tcp(0)));
+        let acceptor = try!(transport::new_acceptor(Port::Tcp(0)));
         let mut guid = [0; GUID_SIZE];
         for i in 0..GUID_SIZE {
             guid[i] = random::<u8>();

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -166,7 +166,8 @@ impl ConnectionManager {
                 //     PublicKey::Asym(asymmetricbox::PublicKey([0u8; asymmetricbox::PUBLICKEYBYTES]));
 
                 let mut bootstrap_handler = BootstrapHandler::new();
-                let port = &hint.get(0).unwrap_or(&Port::Tcp(0)).clone();
+                let port = hint.get(0).map(|ref e| -> Port { *e.clone() })
+                    .unwrap_or(Port::Tcp(0));
                 self.listen(port);
                 listening_ports = try!(lock_state(&ws, |s| {
                     let buf: Vec<Port> = s.listening_ports.iter().map(|s| s.clone()).collect();
@@ -201,7 +202,8 @@ impl ConnectionManager {
         };
 
         if self.beacon_guid_and_port.is_none() {
-            let port = &hint.get(0).unwrap_or(&Port::Tcp(0)).clone();
+            let port = hint.get(0).map(|ref e| -> Port { *e.clone() })
+                .unwrap_or(Port::Tcp(0));
             self.listen(port);
 
             listening_ports = try!(lock_state(&ws, |s| {
@@ -476,7 +478,7 @@ impl ConnectionManager {
         }
     }
 
-    fn listen(&mut self, port: &Port) {
+    fn listen(&mut self, port: Port) {
         let acceptor = transport::new_acceptor(port).unwrap();
         let local_port = acceptor.local_port();
         self.own_endpoints = map_external_port(&local_port);
@@ -1064,7 +1066,7 @@ mod test {
 
     #[test]
     fn bootstrap_off_list_connects() {
-        let acceptor = transport::new_acceptor(&Port::Tcp(0)).unwrap();
+        let acceptor = transport::new_acceptor(Port::Tcp(0)).unwrap();
         let addr = match acceptor {
             transport::Acceptor::Tcp(_, listener) => listener.local_addr()
                 .unwrap(),

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -30,7 +30,7 @@ use utp::UtpSocket;
 pub type Bytes = Vec<u8>;
 
 /// Enum representing endpoint of supported protocols
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum Endpoint {
     /// TCP endpoint
     Tcp(SocketAddr),
@@ -86,7 +86,7 @@ impl Decodable for Endpoint {
 
 
 /// Enum representing port of supported protocols
-#[derive(Debug, PartialEq, Eq, Hash, Clone, RustcDecodable, RustcEncodable)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, RustcDecodable, RustcEncodable, Copy)]
 pub enum Port {
     /// TCP port
     Tcp(u16),
@@ -106,7 +106,7 @@ impl Port {
 
 impl PartialOrd for Endpoint {
     fn partial_cmp(&self, other: &Endpoint) -> Option<Ordering> {
-        Some(self.cmp(other))
+        Some(self.cmp(&other))
     }
 }
 
@@ -222,14 +222,14 @@ pub fn connect(remote_ep: Endpoint) -> IoResult<Transport> {
     }
 }
 
-pub fn new_acceptor(port: &Port) -> IoResult<Acceptor> {
-    match *port {
-        Port::Tcp(ref port) => {
-            let (receiver, listener) = try!(tcp_connections::listen(*port));
+pub fn new_acceptor(port: Port) -> IoResult<Acceptor> {
+    match port {
+        Port::Tcp(port) => {
+            let (receiver, listener) = try!(tcp_connections::listen(port));
             Ok(Acceptor::Tcp(receiver, listener))
         },
-        Port::Utp(ref port) => {
-            let (receiver, listener) = try!(utp_connections::listen(*port));
+        Port::Utp(port) => {
+            let (receiver, listener) = try!(utp_connections::listen(port));
             Ok(Acceptor::Utp(receiver, listener))
         },
     }


### PR DESCRIPTION
Rust will clone Port and Endpoint automatically for us.

Acceptor doesn't derive from `Copy` and it makes sense, but I see no reason why
`Endpoint` and `Port` don't derive from `Copy`.

For reference: http://doc.rust-lang.org/std/marker/trait.Copy.html

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/216)

<!-- Reviewable:end -->
