### PR TITLE
initial messaging layer

### DIFF
--- a/src/bootstrap_handler.rs
+++ b/src/bootstrap_handler.rs
@@ -22,12 +22,6 @@
 //! This means that none of the public functions of `BootstrapHandler` should be called concurrently
 //! with any other one.
 
-pub fn parse_contacts(buffer: Vec<u8>) -> Result<::contact::Contacts, ::error::Error> {
-    let mut decoder = ::cbor::Decoder::from_bytes(buffer);
-    let items: ::contact::Contacts = try!(decoder.decode().collect::<Result<_, _>>());
-    Ok(items)
-}
-
 pub struct BootstrapHandler {
     file_handler: ::file_handler::FileHandler,
     last_updated: ::time::Tm,
@@ -53,13 +47,6 @@ impl BootstrapHandler {
 
     pub fn read_file(&mut self) -> Result<::contact::Contacts, ::error::Error> {
         self.file_handler.read_file::<::contact::Contacts>()
-    }
-
-    pub fn serialise_contacts(&mut self) -> Result<Vec<u8>, ::error::Error> {
-        let contacts = try!(self.read_file());
-        let mut encoder = ::cbor::Encoder::from_memory();
-        let _ = try!(encoder.encode(&contacts));
-        Ok(encoder.into_bytes())
     }
 
     fn duration_between_updates() -> ::time::Duration {
@@ -251,8 +238,5 @@ mod test {
         let mut bootstrap_handler = super::BootstrapHandler::new();
         assert!(bootstrap_handler.update_contacts(contacts.clone(),
                                                   ::contact::Contacts::new()).is_ok());
-
-        let serialised_contacts = bootstrap_handler.serialise_contacts().unwrap();
-        assert_eq!(contacts, super::parse_contacts(serialised_contacts).unwrap());
     }
 }

--- a/src/connection_manager.rs
+++ b/src/connection_manager.rs
@@ -22,11 +22,11 @@ use std::thread;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4};
 
 use beacon;
-use bootstrap_handler::{BootstrapHandler, parse_contacts};
+use bootstrap_handler::BootstrapHandler;
 use config_handler::{Config, read_config_file};
 use getifaddrs::{getifaddrs, filter_loopback};
 use transport;
-use transport::{Endpoint, Port};
+use transport::{Endpoint, Port, Message};
 
 use asynchronous::{Deferred,ControlFlow};
 use itertools::Itertools;
@@ -66,7 +66,7 @@ pub enum Event {
 }
 
 struct Connection {
-    writer_channel: mpsc::Sender<Bytes>,
+    writer_channel: mpsc::Sender<Message>,
 }
 
 struct State {
@@ -233,8 +233,9 @@ impl ConnectionManager {
                             mut transport: ::transport::Transport) {
         let _ = lock_mut_state(&mut weak_state, |state: &mut State| {
             if let Some(ref mut handler) = state.bootstrap_handler {
-                if let Ok(serialised_contacts) = handler.serialise_contacts() {
-                    let _ = transport.sender.send(&serialised_contacts);
+                if let Ok(contacts) = handler.read_file() {
+                    let msg = Message::Contacts(contacts);
+                    let _ = transport.sender.send(&msg);
                 }
             }
             Ok(())
@@ -398,7 +399,7 @@ impl ConnectionManager {
             }
         }));
 
-        let send_result = writer_channel.send(message);
+        let send_result = writer_channel.send(Message::UserBlob(message));
         let cant_send = io::Error::new(io::ErrorKind::BrokenPipe, "?");
         send_result.map_err(|_|cant_send)
     }
@@ -434,20 +435,20 @@ impl ConnectionManager {
         for peer in peer_addresses {
             let transport = transport::connect(transport::Endpoint::Tcp(peer))
                 .unwrap();
-            let contacts_str = match transport.receiver.receive() {
+            let message = match transport.receiver.receive() {
                 Ok(message) => message,
                 Err(_) => {
                     continue
                 },
             };
 
-            match parse_contacts(contacts_str) {
-                Ok(contacts) => {
+            match message {
+                Message::Contacts(contacts) => {
                     for contact in contacts {
                         endpoints.push(contact.endpoint);
                     }
                 },
-                Err(_) => continue
+                _ => continue
             }
         }
 
@@ -660,8 +661,10 @@ fn start_reading_thread(state: WeakState,
                         sink: mpsc::Sender<Event>) {
     let _ = thread::Builder::new().name("ConnectionManager reader".to_string()).spawn(move || {
         while let Ok(msg) = receiver.receive() {
-            if sink.send(Event::NewMessage(his_ep.clone(), msg)).is_err() {
-                break
+            if let Message::UserBlob(msg) = msg {
+                if sink.send(Event::NewMessage(his_ep.clone(), msg)).is_err() {
+                    break
+                }
             }
         }
         unregister_connection(state, his_ep);
@@ -672,7 +675,7 @@ fn start_reading_thread(state: WeakState,
 fn start_writing_thread(state: WeakState,
                         mut sender: transport::Sender,
                         his_ep: Endpoint,
-                        writer_channel: mpsc::Receiver<Bytes>) {
+                        writer_channel: mpsc::Receiver<Message>) {
     let _ = thread::Builder::new().name("ConnectionManager writer".to_string()).spawn(move || {
         for msg in writer_channel.iter() {
             if sender.send(&msg).is_err() {


### PR DESCRIPTION
An alternative approach could be:

```
enum Event {
    Contacts(Contacts),
}

enum Message {
    External(Bytes),
    Internal(Event),
}
```

But this would be 2 levels of indirection that could be leading to
more inefficient representation. Also, current approach saves typing.

This commits also gets rid of parse_contacts, as the serialization
happens on a central placce.

This support is "initial" because there room for improvement, like adding other
events (e.g. ping...) and find code that could be obsoleted by this approach.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/293)

<!-- Reviewable:end -->
