### PR TITLE
Removes socket_timeout feature and usage of beacon from one test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
        html_favicon_url = "http://maidsafe.net/img/favicon.ico",
        html_root_url = "http://maidsafe.github.io/crust/")]
-#![feature(fnbox, ip_addr, ip, socket_timeout)]
+#![feature(fnbox, ip_addr, ip)]
 #![allow(unused_variables)]
 
 extern crate asynchronous;


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/322)

<!-- Reviewable:end -->
