### PR TITLE
fix API breakage introduced in temp_utp 0.6.12

### DIFF
--- a/src/utp_wrapper.rs
+++ b/src/utp_wrapper.rs
@@ -21,7 +21,7 @@ impl UtpWrapper {
     pub fn wrap(socket: UtpSocket) -> io::Result<UtpWrapper> {
         let (itx, irx) = mpsc::channel();
         let (otx, orx) = mpsc::channel::<Vec<u8>>();
-        let peer_addr = socket.peer_addr();
+        let peer_addr = try!(socket.peer_addr());
         let local_addr = try!(socket.local_addr());
 
         let _ = thread::spawn(move || {


### PR DESCRIPTION
Crust depends on UtpSocket::peer_fn, which was introduced earlier in our
temporary fork.

When adopted upstream, this function used a different API, returning
`Result<T>` instead `T`.

temp_utp 0.6.12 was released to match upstream API and our API broke.
This commit fixes that.

More information on the API change reason:

> I disagree that peer_addr should return SocketAddr directly for two
> reasons: a socket's connected_to may be incorrect when the socket is
> in a state other than Connected or FinSent, and I wish to keep the
> library's API as closes as reasonable to TcpStream's.
>   -- https://github.com/meqif/rust-utp/pull/13#issuecomment-148024294

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/358)

<!-- Reviewable:end -->
