### PR TITLE
Join threads, release bound sockets on Service::stop 

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -50,6 +50,7 @@ pub struct Service {
     beacon_guid_and_port : Option<(beacon::GUID, u16)>,
     config               : Config,
     cmd_sender           : Sender<Closure>,
+    state_thread_handle  : Option<JoinHandle<()>>,
 }
 
 impl Service {
@@ -83,14 +84,13 @@ impl Service {
         let mut state = State::new(event_sender, mapper);
         let cmd_sender = state.cmd_sender.clone();
 
-        let handle = try!(Self::new_thread("run loop", move || {
-                                state.run();
-                            }));
+        let handle = try!(Self::new_thread("run loop", move || state.run() ));
 
         let mut service = Service {
                               beacon_guid_and_port : None,
                               config               : config,
                               cmd_sender           : cmd_sender,
+                              state_thread_handle  : Some(handle)
                           };
 
         let beacon_port = service.config.beacon_port.clone();
@@ -211,6 +211,9 @@ impl Service {
     /// This should be called before destroying an instance of a Service to allow the
     /// listener threads to join.  Once called, the Service should be destroyed.
     pub fn stop(&mut self) {
+        use std::net::TcpStream;
+        use utp::UtpSocket;
+
         if let Some(beacon_guid_and_port) = self.beacon_guid_and_port {
             beacon::BroadcastAcceptor::stop(&beacon_guid_and_port);
             self.beacon_guid_and_port = None;
@@ -222,9 +225,18 @@ impl Service {
             // Connect to our listening ports, this should unblock
             // the threads.
             for port in state.listening_ports.iter() {
-                let _ = State::connect(Handshake::default(), ::util::loopback_v4(*port));
+                let addr = ::util::loopback_v4(*port).get_address();
+
+                match *port {
+                    Port::Tcp(_) => { let _ = TcpStream::connect(&addr); },
+                    Port::Utp(_) => { let _ = UtpSocket::connect(&addr); }
+                }
             }
         }));
+
+        if let Some(handle) = self.state_thread_handle.take() {
+            let _ = handle.join();
+        }
     }
 
     /// Opens a connection to a remote peer. `endpoints` is a vector of addresses of the remote
@@ -288,7 +300,8 @@ impl Service {
         let cmd_sender2 = cmd_sender.clone();
 
         Self::post(&cmd_sender, move |state: &mut State| {
-            state.listening_ports.insert(acceptor.local_port());
+            let port = acceptor.local_port();
+            state.listening_ports.insert(port);
 
             let handshake = Handshake {
                 mapper_port: Some(state.mapper.listening_addr().port()),
@@ -299,6 +312,8 @@ impl Service {
                 let cmd_sender3 = cmd_sender2.clone();
 
                 let _ = cmd_sender2.send(Box::new(move |state: &mut State| {
+                    state.listening_ports.remove(&port);
+
                     if state.stop_called {
                         return;
                     }
@@ -536,8 +551,6 @@ mod test {
 
     #[test]
     fn connection_manager() {
-        // Wait 2 seconds until previous bootstrap test ends. If not, that test connects to these endpoints.
-        thread::sleep_ms(2000);
         let run_cm = |cm: Service, o: Receiver<Event>| {
             spawn(move || {
                 for i in o.iter() {
@@ -723,5 +736,27 @@ mod test {
         thread::sleep_ms(100);
 
         let _ = thread.join();
+    }
+
+    #[test]
+    fn reaccept() {
+        let tcp_port;
+        let utp_port;
+
+        {
+            let (sender, _) = channel();
+            let mut service = Service::new(sender).unwrap();
+            // random port assigned by os
+            tcp_port = service.start_accepting(Port::Tcp(0)).unwrap().get_port();
+            utp_port = service.start_accepting(Port::Utp(0)).unwrap().get_port();
+        }
+
+        {
+            let (sender, _) = channel();
+            let mut service = Service::new(sender.clone()).unwrap();
+            // reuse the ports from above
+            let _ = service.start_accepting(tcp_port).unwrap();
+            let _ = service.start_accepting(utp_port).unwrap();
+        }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -322,7 +322,7 @@ impl State {
             Ok(peers) => peers,
             Err(_) => return Vec::<Endpoint>::new(),
         };
-    
+
         // For each contact, connect and receive their list of bootstrap contacts
         let mut endpoints: Vec<Endpoint> = vec![];
         for peer in peer_addresses {
@@ -338,7 +338,7 @@ impl State {
                     continue
                 },
             };
-    
+
             match message {
                 Message::Contacts(new_endpoints) => {
                     for ep in new_endpoints {
@@ -348,7 +348,7 @@ impl State {
                 _ => continue
             }
         }
-    
+
         endpoints
     }
 
@@ -427,7 +427,7 @@ impl State {
         self.stop_called = true;
     }
 
-    fn new_thread<F,T>(name: &str, f: F) -> io::Result<JoinHandle<T>> 
+    fn new_thread<F,T>(name: &str, f: F) -> io::Result<JoinHandle<T>>
             where F: FnOnce() -> T, F: Send + 'static, T: Send + 'static {
         thread::Builder::new().name("State::".to_string() + name)
                               .spawn(f)
@@ -497,7 +497,7 @@ mod test {
 
     fn testable_endpoint(acceptor: &Acceptor) -> Endpoint {
         let addr = match acceptor {
-            &Acceptor::Tcp(_, ref listener) => listener.local_addr()
+            &Acceptor::Tcp(ref listener) => listener.local_addr()
                 .unwrap(),
             _ => panic!("Unable to create a new connection"),
         };

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -26,7 +26,7 @@ use std::sync::mpsc;
 use cbor;
 use std::str::FromStr;
 use rustc_serialize::{Decodable, Decoder, Encodable, Encoder};
-use utp::UtpSocket;
+use utp::UtpListener;
 use std::fmt;
 use ip;
 use connection::Connection;
@@ -281,37 +281,41 @@ impl Receiver {
 
 //--------------------------------------------------------------------
 pub enum Acceptor {
-    // Channel receiver, TCP listener
-    Tcp(mpsc::Receiver<(TcpStream, SocketAddr)>, TcpListener),
-    // Channel receiver, UTP listener and port
-    Utp(mpsc::Receiver<(UtpSocket, SocketAddr)>, SocketAddr),
+    // TCP listener
+    Tcp(TcpListener),
+    // UTP listener
+    Utp(UtpListener),
 }
 
 impl Acceptor {
     pub fn new(port: Port) -> IoResult<Acceptor> {
         match port {
             Port::Tcp(port) => {
-                let (receiver, listener) = try!(tcp_connections::listen(port));
-                Ok(Acceptor::Tcp(receiver, listener))
+                let listener = {
+                    if let Ok(listener) = TcpListener::bind(("0.0.0.0", port)) {
+                        listener
+                    } else {
+                        try!(TcpListener::bind(("0.0.0.0", 0)))
+                    }
+                };
+
+                Ok(Acceptor::Tcp(listener))
             },
             Port::Utp(port) => {
-                let (receiver, listener) = try!(utp_connections::listen(port));
-                Ok(Acceptor::Utp(receiver, listener))
+                let listener = try!(UtpListener::bind(("0.0.0.0", port)));
+                Ok(Acceptor::Utp(listener))
             },
         }
     }
 
     pub fn local_port(&self) -> Port {
-        match *self {
-            Acceptor::Tcp(_, ref listener) => Port::Tcp(listener.local_addr().unwrap().port()),
-            Acceptor::Utp(_, local_addr) => Port::Utp(local_addr.port()),
-        }
+        self.local_addr().get_port()
     }
 
     pub fn local_addr(&self) -> Endpoint {
         match *self {
-            Acceptor::Tcp(_, ref listener) => Endpoint::Tcp(listener.local_addr().unwrap()),
-            Acceptor::Utp(_, local_addr) => Endpoint::Utp(local_addr),
+            Acceptor::Tcp(ref listener) => Endpoint::Tcp(listener.local_addr().unwrap()),
+            Acceptor::Utp(ref listener) => Endpoint::Utp(listener.local_addr().unwrap()),
         }
     }
 }
@@ -371,9 +375,8 @@ pub fn connect(remote_ep: Endpoint) -> IoResult<Transport> {
 // (Though this seems to be impossible with the current Rust TCP API).
 pub fn accept(acceptor: &Acceptor) -> IoResult<Transport> {
     match *acceptor {
-        Acceptor::Tcp(ref rx_channel, _) => {
-            let rx = rx_channel.recv();
-            let (stream, remote_endpoint) = try!(rx
+        Acceptor::Tcp(ref listener) => {
+            let (stream, remote_endpoint) = try!(listener.accept()
                 .map_err(|e| io::Error::new(io::ErrorKind::NotConnected, e.description())));
 
             let (i, o) = try!(tcp_connections::upgrade_tcp(stream));
@@ -390,8 +393,8 @@ pub fn accept(acceptor: &Acceptor) -> IoResult<Transport> {
                 connection_id: connection_id,
             })
         },
-        Acceptor::Utp(ref rx_channel, _) => {
-            let (stream, remote_endpoint) = try!(rx_channel.recv()
+        Acceptor::Utp(ref listener) => {
+            let (stream, remote_endpoint) = try!(listener.accept()
                 .map_err(|e| io::Error::new(io::ErrorKind::NotConnected, e.description())));
 
             let (i, o) = try!(utp_connections::upgrade_utp(stream));

--- a/src/utp_connections.rs
+++ b/src/utp_connections.rs
@@ -15,39 +15,16 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use utp::{UtpSocket, UtpListener};
+use utp::UtpSocket;
 pub use utp_wrapper::UtpWrapper;
-use std::net::{SocketAddr, SocketAddrV4, Ipv4Addr};
+use std::net::SocketAddr;
 use std::io::Result as IoResult;
-use std::sync::mpsc::{Sender, Receiver};
-use std::sync::mpsc;
-use std::thread;
+use std::sync::mpsc::Sender;
 
 /// Connect to a peer and open a send-receive pair.  See `upgrade` for more details.
 pub fn connect_utp(addr: SocketAddr)
                    -> IoResult<(UtpWrapper, Sender<Vec<u8>>)> {
     upgrade_utp(try!(UtpSocket::connect(addr)))
-}
-
-/// Starts listening for connections on this ip and port.
-/// Returns:
-/// * A receiver of Utp socket objects.  It is recommended that you `upgrade` these.
-/// * Port
-pub fn listen(port: u16) -> IoResult<(Receiver<(UtpSocket, SocketAddr)>, SocketAddr)> {
-    let listener = try!(UtpListener::bind(SocketAddr::V4({
-        SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), port)
-    })));
-    let local_addr = try!(listener.local_addr());
-    let (tx, rx) = mpsc::channel();
-    let _ = thread::spawn(move || {
-        loop {
-            match listener.accept() {
-                Ok(s) => if tx.send(s).is_err() { break },
-                Err(_) => break,
-            }
-        }
-    });
-    Ok((rx, local_addr))
 }
 
 /// Upgrades a newly connected UtpSocket to a Sender-Receiver pair that you can use to send and
@@ -65,7 +42,12 @@ mod test {
     use super::*;
     use std::thread;
     use std::net::{SocketAddr, SocketAddrV4, Ipv4Addr, UdpSocket};
-    use std::io::Read;
+    use std::io::{Read, Result};
+    use utp::UtpListener;
+
+    fn listen(port: u16) -> Result<UtpListener> {
+        UtpListener::bind(("0.0.0.0", port))
+    }
 
     #[test]
     fn cannot_establish_connection() {
@@ -82,30 +64,43 @@ mod test {
     #[test]
     fn establishing_connection() {
         let listener = listen(0).unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let handle = thread::spawn(move || listener.accept().unwrap());
+
         let _ = connect_utp(SocketAddr::V4({
-            SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), listener.1.port())
+            SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), port)
         })).unwrap();
+
+        let _ = handle.join().unwrap();
     }
 
     #[test]
     fn send_receive_data() {
         let listener = listen(0).unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let th0 = thread::spawn(move || {
+            let s = listener.accept().unwrap().0;
+            let (mut i, o) = upgrade_utp(s).unwrap();
+            let mut buf = [0u8; 1];
+            let _ = i.read(&mut buf).unwrap();
+            assert_eq!(buf[0], 42);
+            o.send(vec![43]);
+        });
+
         let (mut i, o) = connect_utp(SocketAddr::V4({
-            SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), listener.1.port())
+            SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), port)
         })).unwrap();
-        let listener = listener.0;
-        let thread = thread::spawn(move || {
+
+        let th1 = thread::spawn(move || {
             o.send(vec![42]);
             let mut buf = [0u8; 1];
             let _ = i.read(&mut buf).unwrap();
             assert_eq!(buf[0], 43);
         });
-        let s = listener.recv().unwrap().0;
-        let (mut i, o) = upgrade_utp(s).unwrap();
-        let mut buf = [0u8; 1];
-        let _ = i.read(&mut buf).unwrap();
-        assert_eq!(buf[0], 42);
-        o.send(vec![43]);
-        thread.join();
+
+        th1.join();
+        th0.join();
     }
 }


### PR DESCRIPTION
1. Adds join of the `State` thread on `Service::stop`
2. Simplifies acceptor logic (both TCP and UTP) by removing unnecessary threads. This also fixes #361 .

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/376)

<!-- Reviewable:end -->
