### PR TITLE
Add --connect-immediately config to the reporter example

### DIFF
--- a/examples/reporter.rs
+++ b/examples/reporter.rs
@@ -225,7 +225,7 @@ impl Report {
     fn record_event(&mut self, event: &Event) {
         self.events.push(Some(EventEntry {
             timestamp:   time::now(),
-            description: format!("{:?}", event)
+            description: format_event(event)
         }));
     }
 
@@ -253,6 +253,16 @@ impl Encodable for EventEntry {
     fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), E::Error> {
         let timestamp_string = format!("{}", self.timestamp.rfc3339());
         [&timestamp_string, &self.description].encode(encoder)
+    }
+}
+
+fn format_event(event: &Event) -> String {
+    match *event {
+        Event::NewMessage(ref connection, ref data) => {
+            format!("NewMessage({:?}, \"{}\")", connection,
+                    String::from_utf8_lossy(&data))
+        },
+        _ => format!("{:?}", event)
     }
 }
 


### PR DESCRIPTION
Without the flag, the node will wait until someone connects to it first before it connects to all the nodes specified in its config file. With the flag, the node starts connecting immediately.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/377)

<!-- Reviewable:end -->
