### PR TITLE
Duration precision fix

### DIFF
--- a/src/socket_utils.rs
+++ b/src/socket_utils.rs
@@ -12,30 +12,31 @@ impl RecvUntil for UdpSocket {
     fn recv_until(&self, buf: &mut [u8], deadline: ::time::SteadyTime) -> io::Result<Option<(usize, SocketAddr)>> {
         loop {
             let current_time = ::time::SteadyTime::now();
-            let timeout = deadline - current_time;
-            if timeout <= ::time::Duration::zero() {
+            let timeout_ms = (deadline - current_time).num_milliseconds();
+
+            if timeout_ms <= 0 {
                 return Ok(None);
             }
-            else {
-                // TODO (canndrew): should eventually be able to remove this conversion
-                let timeout = ::std::time::Duration::from_millis(timeout.num_milliseconds() as u64);
-                try!(self.set_read_timeout(Some(timeout)));
-                match self.recv_from(buf) {
-                    Ok(x)   => return Ok(Some(x)),
-                    Err(e)  => match e.kind() {
-                        ErrorKind::TimedOut | ErrorKind::WouldBlock => return Ok(None),
-                        ErrorKind::Interrupted => (),
-                        // On Windows, when we send a packet to an endpoint
-                        // which is not being listened on, the system responds
-                        // with an ICMP packet "ICMP port unreachable".
-                        // We do not care about this silly behavior, so we just
-                        // ignore it.
-                        // See here for more info:
-                        // https://bobobobo.wordpress.com/2009/05/17/udp-an-existing-connection-was-forcibly-closed-by-the-remote-host/
-                        ErrorKind::ConnectionReset => (),
-                        _   => return Err(e),
-                    },
-                }
+
+            // TODO (canndrew): should eventually be able to remove this conversion
+            let timeout = ::std::time::Duration::from_millis(timeout_ms as u64);
+            try!(self.set_read_timeout(Some(timeout)));
+
+            match self.recv_from(buf) {
+                Ok(x)   => return Ok(Some(x)),
+                Err(e)  => match e.kind() {
+                    ErrorKind::TimedOut | ErrorKind::WouldBlock => return Ok(None),
+                    ErrorKind::Interrupted => (),
+                    // On Windows, when we send a packet to an endpoint
+                    // which is not being listened on, the system responds
+                    // with an ICMP packet "ICMP port unreachable".
+                    // We do not care about this silly behavior, so we just
+                    // ignore it.
+                    // See here for more info:
+                    // https://bobobobo.wordpress.com/2009/05/17/udp-an-existing-connection-was-forcibly-closed-by-the-remote-host/
+                    ErrorKind::ConnectionReset => (),
+                    _   => return Err(e),
+                },
             }
         }
     }


### PR DESCRIPTION
When the timeout was less than 1ms but bugger than 0ms, the
conversion to ms and then back to Duration resulted in
zero duration, which the set_read_timeout fn did not like
on windows.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/389)

<!-- Reviewable:end -->
