### PR TITLE
Removes use of asynchronous::Deferred from bootstrap_off_list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ rand = "*"
 rustc-serialize = "*"
 term = "*"
 time = "*"
-asynchronous = "*"
 itertools = "*"
 igd = { version = "0.2.1", features = [ "unstable" ] }
 net2 = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@
          missing_debug_implementations)]
 #![feature(fnbox, ip_addr, ip)]
 
-extern crate asynchronous;
 extern crate cbor;
 extern crate igd;
 extern crate itertools;


### PR DESCRIPTION
And removes the dependency to 'asynchronous' from Cargo.toml.
It was not needed as we're currently not bootstrapping in parallel
anyway and the library was causing misterious panics on Os X when
we tried to bootstrap off more than 47 nodes.

fixes #382

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/390)
<!-- Reviewable:end -->
