### PR TITLE
Nightly fixes

### DIFF
--- a/src/beacon.rs
+++ b/src/beacon.rs
@@ -242,7 +242,7 @@ pub fn seek_peers(port: u16, guid_to_avoid: Option<GUID>) -> Result<Vec<SocketAd
     let _shutdown_thread = thread::Builder::new()
             .name("Beacon seek_peers UDP shutdown".to_string())
             .spawn(move || {
-        thread::sleep_ms(500);
+        thread::sleep(Duration::from_millis(500));
         let killer_socket = match UdpSocket::bind("0.0.0.0:0") {
             Ok(socket) => socket,
             Err(_) => return (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@
         unconditional_recursion, unknown_lints, unsafe_code, unused, unused_allocation,
         unused_attributes, unused_comparisons, unused_features, unused_parens, while_true)]
 #![warn(trivial_casts, trivial_numeric_casts, unused_extern_crates, unused_import_braces,
-        unused_qualifications, unused_results, variant_size_differences)]
+        unused_qualifications, variant_size_differences)]
 #![allow(box_pointers, fat_ptr_transmutes, missing_copy_implementations,
          missing_debug_implementations)]
 #![feature(fnbox, ip_addr, ip)]

--- a/src/periodic_sender.rs
+++ b/src/periodic_sender.rs
@@ -15,7 +15,7 @@ impl<'a, 'b: 'a, D: AsRef<[u8]> + Send + 'b> PeriodicSender<D> {
             destination: SocketAddr,
             scope: &::crossbeam::Scope<'a>,
             data: D,
-            period_ms: u32
+            period: ::std::time::Duration
         ) -> PeriodicSender<D>
     {
         let (tx, rx) = ::std::sync::mpsc::channel::<()>();
@@ -30,7 +30,7 @@ impl<'a, 'b: 'a, D: AsRef<[u8]> + Send + 'b> PeriodicSender<D> {
                 // see: https://github.com/rust-lang/rfcs/issues/523
                 // see: https://github.com/rust-lang/rfcs/issues/814
                 let _ = udp_socket.send_to(data.as_ref(), destination);
-                ::std::thread::park_timeout_ms(period_ms);
+                ::std::thread::park_timeout(period);
                 match rx.try_recv() {
                     Err(::std::sync::mpsc::TryRecvError::Empty)        => (),
                     Err(::std::sync::mpsc::TryRecvError::Disconnected) => panic!(),


### PR DESCRIPTION
Fixes for crust being broken on nightly.

**Note:** Commit a0b210e removes the `unused_results` lint because it apparently conflicts with `#[derive(Debug)]`. This commit should be reverted as soon as this is fixed upstream.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/409)

<!-- Reviewable:end -->
