### PR TITLE
Nightly fixes

### DIFF
--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -24,7 +24,7 @@
         unsafe_code, unused_allocation, unused_attributes,
         unused_comparisons, unused_features, unused_parens, while_true)]
 #![warn(trivial_casts, trivial_numeric_casts, unused, unused_extern_crates, unused_import_braces,
-        unused_qualifications, unused_results, variant_size_differences)]
+        unused_qualifications, variant_size_differences)]
 
 #[macro_use]
 extern crate log;

--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -49,6 +49,7 @@ use std::collections::HashSet;
 use std::str::FromStr;
 use std::thread;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use crust::{Service, Endpoint, Connection};
 
@@ -346,10 +347,10 @@ fn reset_foreground(stdout: Option<Box<term::StdoutTerminal>>) ->
 // If bootstrap doesn't succeed in n seconds and we're trying to run the speed test, then fail overall.
 // Otherwise, if no peer endpoints were provided and bootstrapping fails, assume this is
 // OK, i.e. this is the first node of a new network.
-fn on_time_out(ms: u32, flag_speed: bool) -> Sender<bool> {
+fn on_time_out(timeout: Duration, flag_speed: bool) -> Sender<bool> {
     let (tx, rx) = channel();
     let _ = std::thread::spawn(move || {
-        std::thread::sleep_ms(ms);
+        std::thread::sleep(timeout);
         match rx.try_recv() {
             Ok(true) => {},
             _ => {
@@ -536,7 +537,7 @@ fn main() {
     };
 
     if running_speed_test {  // Processing interaction till receiving ctrl+C
-        let tx = on_time_out(5000, running_speed_test);
+        let tx = on_time_out(Duration::from_secs(5), running_speed_test);
 
         // Block until we get one bootstrap connection
         let connected_peer = bs_receiver.recv().unwrap_or_else(|e| {
@@ -550,7 +551,7 @@ fn main() {
 
         let _ = tx.send(true); // stop timer with no error messages
 
-        thread::sleep_ms(100);
+        thread::sleep(Duration::from_millis(100));
         println!("");
 
         let speed = args.flag_speed.unwrap();  // Safe due to `running_speed_test` == true
@@ -563,7 +564,7 @@ fn main() {
             for _ in 0..times {
                 service.send(peer.clone(), generate_random_vec_u8(length as usize));
                 debug!("Sent a message with length of {} bytes to {:?}", length, peer);
-                std::thread::sleep_ms(sleep_time as u32);
+                std::thread::sleep(Duration::from_millis(sleep_time));
             }
         }
     } else {

--- a/examples/reporter.rs
+++ b/examples/reporter.rs
@@ -97,8 +97,8 @@ Explanation of the config fields:
 See also the example config files in examples/reporter directory.
 "#;
 
-const MIN_RUN_TIME_MS: u32 = 1000;
-const MAX_RUN_TIME_MS: u32 = 2500;
+const MIN_RUN_TIME_MS: u64 = 1000;
+const MAX_RUN_TIME_MS: u64 = 2500;
 
 fn main() {
     match env_logger::init() {
@@ -124,8 +124,8 @@ fn main() {
         report.update(run(connected.clone(), &config));
         debug!("Service stopped ({} of {})", i + 1, config.service_runs);
 
-        thread::sleep_ms(thread_rng().gen_range(
-            0, config.max_wait_before_restart_service_secs * 1000));
+        thread::sleep(::std::time::Duration::from_millis(thread_rng().gen_range(
+            0, config.max_wait_before_restart_service_secs * 1000)));
     }
 
     let mut file_handler = FileHandler::new(Path::new(&config.output_report_path).to_path_buf());
@@ -145,7 +145,7 @@ struct Config {
     listening_port:                       Option<u16>,
     service_runs:                         u64,
     output_report_path:                   String,
-    max_wait_before_restart_service_secs: u32
+    max_wait_before_restart_service_secs: u64
 }
 
 impl Config {
@@ -350,7 +350,7 @@ fn run(connected: Arc<AtomicBool>, config: &Config) -> Report {
     // Wait until someone connects to us.
     let _ = wait_receiver.recv();
 
-    thread::sleep_ms(thread_rng().gen_range(MIN_RUN_TIME_MS, MAX_RUN_TIME_MS));
+    thread::sleep(::std::time::Duration::from_millis(thread_rng().gen_range(MIN_RUN_TIME_MS, MAX_RUN_TIME_MS)));
 
     message_sender1.send(None).unwrap();
     message_thread_handle.join().unwrap();

--- a/examples/reporter.rs
+++ b/examples/reporter.rs
@@ -24,7 +24,7 @@
         unsafe_code, unused_allocation, unused_attributes,
         unused_comparisons, unused_features, unused_parens, while_true)]
 #![warn(trivial_casts, trivial_numeric_casts, unused, unused_extern_crates, unused_import_braces,
-        unused_qualifications, unused_results, variant_size_differences)]
+        unused_qualifications, variant_size_differences)]
 
 extern crate crust;
 extern crate docopt;

--- a/examples/simple_sender.rs
+++ b/examples/simple_sender.rs
@@ -98,5 +98,5 @@ fn main() {
     }
 
     // Allow the peer time to process the requests and reply.
-    ::std::thread::sleep_ms(2000);
+    ::std::thread::sleep(::std::time::Duration::from_secs(2));
 }

--- a/src/beacon.rs
+++ b/src/beacon.rs
@@ -315,7 +315,7 @@ mod test {
         // This one is just so that the first thread breaks.
         let t3 = thread::Builder::new().name("test_avoid_beacon seek_peers 2".to_string())
                                        .spawn(move || {
-            thread::sleep_ms(700);
+            thread::sleep(::std::time::Duration::from_millis(700));
             let endpoint = seek_peers(acceptor_port, None).unwrap()[0];
             let _ = State::connect(Handshake::default(),
                                    transport::Endpoint::Tcp(endpoint)).unwrap();

--- a/src/map_external_port.rs
+++ b/src/map_external_port.rs
@@ -149,7 +149,7 @@ mod test {
             assert!(sender.send(result).is_ok());
         }));
 
-        let igd_result = match timed_recv(&receiver, 3000) {
+        let igd_result = match timed_recv(&receiver, ::std::time::Duration::from_secs(3)) {
             Ok(igd_result) => igd_result,
             Err(what) => panic!(what),
         };

--- a/src/service.rs
+++ b/src/service.rs
@@ -579,7 +579,7 @@ mod test {
         let cm1_ports = filter_ok(cm1.start_default_acceptors());
         assert_eq!(cm1_ports.len(), 1);
 
-        thread::sleep_ms(1000);
+        thread::sleep(::std::time::Duration::from_secs(1));
         let _config_file = make_temp_config(cm1.get_beacon_acceptor_port());
 
         let (cm2_i, cm2_o) = channel();
@@ -592,7 +592,7 @@ mod test {
         let mut result = Err(::std::sync::mpsc::TryRecvError::Empty);
         while ::time::now() < start + timeout && result.is_err() {
             result = cm2_o.try_recv();
-            ::std::thread::sleep_ms(100);
+            ::std::thread::sleep(::std::time::Duration::from_millis(100));
         }
         match result {
             Ok(Event::OnConnect(ep, _)) => {
@@ -660,7 +660,7 @@ mod test {
         BootstrapHandler::cleanup().unwrap();
 
         // Wait 2 seconds until previous bootstrap test ends. If not, that test connects to these endpoints.
-        thread::sleep_ms(2000);
+        thread::sleep(::std::time::Duration::from_secs(2));
         let run_cm = |cm: Service, o: Receiver<Event>,
                       shutdown_recver: Receiver<()>, ready_sender: Sender<()>| {
             spawn(move || {
@@ -863,7 +863,7 @@ mod test {
                 }
             }
         }).join();
-        thread::sleep_ms(100);
+        thread::sleep(::std::time::Duration::from_millis(100));
 
         let _ = thread.join();
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -394,17 +394,17 @@ pub fn random_global_endpoints(count: usize) -> Vec<::transport::Endpoint> {
 }
 
 #[cfg(test)]
-pub fn timed_recv<T>(receiver: &mpsc::Receiver<T>, timeout_ms: u32)
+pub fn timed_recv<T>(receiver: &mpsc::Receiver<T>, timeout: ::std::time::Duration)
                      -> Result<T, mpsc::TryRecvError>
 {
-    let step_ms = 20;
-    let mut time = 0;
+    let step = ::std::time::Duration::from_millis(20);
+    let mut time = ::std::time::Duration::new(0, 0);
     loop {
         match receiver.try_recv() {
             Ok(v) => return Ok(v),
             Err(what) => match what {
                 mpsc::TryRecvError::Empty => {
-                    if time >= timeout_ms {
+                    if time >= timeout {
                         return Err(what);
                     }
                 },
@@ -413,8 +413,8 @@ pub fn timed_recv<T>(receiver: &mpsc::Receiver<T>, timeout_ms: u32)
                 }
             }
         }
-        thread::sleep_ms(step_ms);
-        time += step_ms;
+        thread::sleep(step);
+        time = time + step;
     }
 }
 


### PR DESCRIPTION
More changes for [this bug](https://github.com/maidsafe/crust/issues/408). This is an extension of [this PR](https://github.com/maidsafe/crust/pull/409).

**Note:** Commit 4a8b05c removes the `unused_results` lint because it apparently conflicts with `#[derive(Debug)]`. This commit should be reverted as soon as this is fixed upstream.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/411)

<!-- Reviewable:end -->
