### PR TITLE
beaconing cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ net2 = "~0.2.17"
 temp_utp = "~0.6.19"
 log = "~0.3.3"
 crossbeam = "~0.1.6"
+memmap = "0.2.2"
 
 [dev-dependencies]
 env_logger = "~0.3.2"

--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -83,6 +83,8 @@ Options:
   -h, --help                 Display this help message.
 ";
 
+const BEACON_PORT: u16 = 5484;
+
 #[derive(RustcDecodable, Debug)]
 struct Args {
     flag_create_local_config: bool,
@@ -396,7 +398,7 @@ fn create_local_config() {
         },
         Err(_) => {  // Continue if the file doesn't exist
             // This test helper function will use defaults for each `None` value.
-            match ::crust::write_config_file(None, None, None, None, None) {
+            match ::crust::write_config_file(None, None, None, None) {
                 Ok(file_path) => {
                     stdout = green_foreground(stdout);
                     println!("Created default config file at {:?}.", file_path);
@@ -440,6 +442,7 @@ fn main() {
     let mut service = Service::new(channel_sender).unwrap();
     let listening_ports = filter_ok(service.start_default_acceptors());
     assert!(listening_ports.len() >= 1);
+    let _ = service.start_beacon(BEACON_PORT);
 
     stdout = green_foreground(stdout);
     print!("Listening on ports");
@@ -449,7 +452,7 @@ fn main() {
     println!("");
 
     stdout = reset_foreground(stdout);
-    service.bootstrap(0);
+    service.bootstrap(0, Some(BEACON_PORT));
 
     let network = Arc::new(Mutex::new(Network::new()));
     let network2 = network.clone();

--- a/examples/simple_sender.rs
+++ b/examples/simple_sender.rs
@@ -75,7 +75,7 @@ fn main() {
         println!("Stopped receiving.");
     });
 
-    service.bootstrap(0);
+    service.bootstrap(0, None);
 
     println!("Service trying to bootstrap off node listening on TCP port 8888 \
               and UDP broadcast port 5484");

--- a/installer/sample.config
+++ b/installer/sample.config
@@ -51,6 +51,5 @@
       "protocol": "utp",
       "address": "45.79.2.52:5483"
     }
-  ],
-  "beacon_port": 5484
+  ]
 }

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -28,7 +28,6 @@ pub struct Config {
     pub utp_listening_port         : Option<u16>,
     pub override_default_bootstrap : bool,
     pub hard_coded_contacts        : Vec<::transport::Endpoint>,
-    pub beacon_port                : Option<u16>,
 }
 
 impl Config {
@@ -38,7 +37,6 @@ impl Config {
             utp_listening_port         : None,
             override_default_bootstrap : false,  // Default bootstrapping methods enabled
             hard_coded_contacts        : vec![],  // No hardcoded endpoints
-            beacon_port                : Some(5484u16),  // LIVE port
         }
     }
 
@@ -49,7 +47,6 @@ impl Config {
             utp_listening_port         : None,
             override_default_bootstrap : true,    // Default bootstrapping methods disabled
             hard_coded_contacts        : vec![],  // No hardcoded endpoints
-            beacon_port                : None,    // LIVE port
         }
     }
 }
@@ -76,8 +73,7 @@ pub fn create_default_config_file() {
 pub fn write_config_file(tcp_listening_port: Option<u16>,
                          utp_listening_port: Option<u16>,
                          override_default_bootstrap: Option<bool>,
-                         hard_coded_endpoints: Option<Vec<::transport::Endpoint>>,
-                         beacon_port: Option<u16>) -> Result<::std::path::PathBuf, ::error::Error> {
+                         hard_coded_endpoints: Option<Vec<::transport::Endpoint>>) -> Result<::std::path::PathBuf, ::error::Error> {
     use std::io::Write;
 
     let default = Config::make_default();
@@ -88,7 +84,6 @@ pub fn write_config_file(tcp_listening_port: Option<u16>,
                             .unwrap_or(default.override_default_bootstrap),
                          hard_coded_contacts: hard_coded_endpoints
                             .unwrap_or(default.hard_coded_contacts),
-                         beacon_port: beacon_port.or(default.beacon_port),
                        };
     let mut config_path = try!(::file_handler::current_bin_dir());
     config_path.push(get_file_name());
@@ -122,12 +117,10 @@ mod test {
                 utp_listening_port: None,
                 override_default_bootstrap: false,
                 hard_coded_contacts: hard_coded_contacts,
-                beacon_port: Some(::rand::random::<u16>()),
             };
         let _ = super::write_config_file(None, None,
                                          Some(config.override_default_bootstrap),
-                                         Some(hard_coded_endpoints),
-                                         config.beacon_port);
+                                         Some(hard_coded_endpoints));
         match super::read_config_file() {
             Ok(recovered_config) => assert_eq!(config, recovered_config),
             Err(_) => panic!("Failed to read config file."),

--- a/src/file_handler.rs
+++ b/src/file_handler.rs
@@ -261,13 +261,20 @@ impl FileHandler {
         }
     }
 
+    #[allow(unsafe_code)]
     fn write<Contents: ::rustc_serialize::Encodable>(path: ::std::path::PathBuf,
                                                      contents: &Contents) ->
             Result<(), ::error::Error> {
+        use memmap::{Mmap, Protection};
+        use rustc_serialize::json;
+        use std::fs::OpenOptions;
         use std::io::Write;
-        let mut file = try!(::std::fs::File::create(path));
-        let _ = try!(write!(&mut file, "{}", ::rustc_serialize::json::as_pretty_json(contents)));
-        file.sync_all().map_err(|error| ::error::Error::IoError(error))
+        let contents = format!("{}", json::as_pretty_json(contents)).into_bytes();
+        let file = try!(OpenOptions::new().read(true).write(true).create(true).open(path));
+        try!(file.set_len(contents.len() as u64));
+        let mut mmap = try!(Mmap::open(&file, Protection::ReadWrite));
+        try!(unsafe { mmap.as_mut_slice() }.write_all(&contents[..]));
+        mmap.flush().map_err(|error| ::error::Error::IoError(error))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ extern crate rustc_serialize;
 extern crate time;
 extern crate utp;
 extern crate crossbeam;
+extern crate memmap;
 
 /// Module implementing the `Service` which provides an interface to manage peer-to-peer
 /// connections.

--- a/src/service.rs
+++ b/src/service.rs
@@ -61,25 +61,8 @@ impl Service {
         let config = read_config_file().unwrap_or_else(|e| {
             debug!("Crust failed to read config file; Error: {:?};", e);
             ::config_handler::create_default_config_file();
-            let default = Config::make_default();
-            debug!("Using default beacon_port {:?} and default bootstrapping methods enabled",
-                default.beacon_port);
-            default
-        });
-
-        Service::construct(event_sender, config)
-    }
-
-    /// Construct a service. As with the `Service::new` function, but will
-    /// ignore beaconing (i.e. assumes `beacon_port` of config file is `null`
-    /// and proceeds).
-    pub fn with_no_beacon(event_sender: Sender<Event>) -> io::Result<Service> {
-        let mut config = read_config_file().unwrap_or_else(|e| {
-            debug!("Crust failed to read config file; Error: {:?};", e);
-            ::config_handler::create_default_config_file();
             Config::make_default()
         });
-        config.beacon_port = None;
 
         Service::construct(event_sender, config)
     }
@@ -101,18 +84,12 @@ impl Service {
                                 state.run();
                             }));
 
-        let mut service = Service {
-                              beacon_guid_and_port : None,
-                              config               : config,
-                              cmd_sender           : cmd_sender,
-                              state_thread_handle  : Some(handle)
-                          };
-
-        let beacon_port = service.config.beacon_port.clone();
-
-        if let Some(port) = beacon_port {
-            let _ = service.start_broadcast_acceptor(port);
-        }
+        let service = Service {
+                          beacon_guid_and_port : None,
+                          config               : config,
+                          cmd_sender           : cmd_sender,
+                          state_thread_handle  : Some(handle)
+                      };
 
         Ok(service)
     }
@@ -135,6 +112,15 @@ impl Service {
         }
 
         result
+    }
+
+    /// Start the beaconing on port `udp_port`. If port number is 0, the OS will
+    /// pick one randomly. The actual port used will be returned.
+    ///
+    /// This function MUST NOT be called more than once. Currently crust has a
+    /// limit of listenning at most once per process.
+    pub fn start_beacon(&mut self, udp_port: u16) -> io::Result<u16> {
+        self.start_broadcast_acceptor(udp_port)
     }
 
     /// Starts accepting on a given port. If port number is 0, the OS
@@ -160,12 +146,13 @@ impl Service {
         Ok(accept_addr)
     }
 
-    fn start_broadcast_acceptor(&mut self, beacon_port: u16) -> io::Result<()> {
+    fn start_broadcast_acceptor(&mut self, beacon_port: u16) -> io::Result<u16> {
         let acceptor = try!(beacon::BroadcastAcceptor::new(beacon_port));
+        let beacon_port = acceptor.beacon_port();
 
         // Right now we expect this function to succeed only once.
         assert!(self.beacon_guid_and_port.is_none());
-        self.beacon_guid_and_port = Some((acceptor.beacon_guid(), acceptor.beacon_port()));
+        self.beacon_guid_and_port = Some((acceptor.beacon_guid(), beacon_port));
 
         let sender = self.cmd_sender.clone();
 
@@ -185,7 +172,7 @@ impl Service {
             assert!(thread_result.is_ok());
         });
 
-        Ok(())
+        Ok(beacon_port)
     }
 
     /// This method tries to connect (bootstrap to existing network) to the default or provided
@@ -206,12 +193,12 @@ impl Service {
     /// This method returns immediately after dropping any active connections.endpoints
     /// New bootstrap connections will be notified by `NewBootstrapConnection` event.
     /// Its upper layer's responsibility to maintain or drop these connections.
-    pub fn bootstrap(&mut self, token: u32) {
+    pub fn bootstrap(&mut self, token: u32, beacon_port: Option<u16>) {
         let config = self.config.clone();
         let beacon_guid_and_port = self.beacon_guid_and_port.clone();
 
         Self::post(&self.cmd_sender, move |state : &mut State| {
-            let contacts = state.populate_bootstrap_contacts(&config, &beacon_guid_and_port);
+            let contacts = state.populate_bootstrap_contacts(&config, beacon_port, &beacon_guid_and_port);
             state.bootstrap_off_list(token,
                                      contacts.clone(),
                                      beacon_guid_and_port.is_some());
@@ -576,10 +563,9 @@ mod test {
         }
     }
 
-    fn make_temp_config(beacon_port: Option<u16>) -> TestConfigFile {
+    fn make_temp_config() -> TestConfigFile {
         let path = write_config_file(Some(5483u16), None, Some(false),
-                                     Some(vec![]),
-                                     Some(beacon_port.unwrap_or(0u16)))
+                                     Some(vec![]))
             .unwrap();
         TestConfigFile{path: path}
     }
@@ -598,19 +584,21 @@ mod test {
 
         let _cleaner = ::file_handler::ScopedUserAppDirRemover;
         let (cm1_i, _) = channel();
-        let _config_file = make_temp_config(None);
+        let _config_file = make_temp_config();
 
         let mut cm1 = Service::new(cm1_i).unwrap();
         let cm1_ports = filter_ok(cm1.start_default_acceptors());
+        let beacon_port = cm1.start_beacon(0).unwrap();
         assert_eq!(cm1_ports.len(), 1);
+        assert_eq!(Some(beacon_port), cm1.get_beacon_acceptor_port());
 
         thread::sleep(::std::time::Duration::from_secs(1));
-        let _config_file = make_temp_config(cm1.get_beacon_acceptor_port());
+        let _config_file = make_temp_config();
 
         let (cm2_i, cm2_o) = channel();
         let mut cm2 = Service::new(cm2_i).unwrap();
 
-        cm2.bootstrap(0);
+        cm2.bootstrap(0, Some(beacon_port));
 
         let timeout = ::time::Duration::seconds(5);
         let start = ::time::now();
@@ -656,14 +644,14 @@ mod test {
             })
         };
 
-        let mut temp_configs = vec![make_temp_config(None)];
+        let mut temp_configs = vec![make_temp_config()];
 
         let (cm1_i, cm1_o) = channel();
         let mut cm1 = Service::new(cm1_i).unwrap();
         let cm1_eps = filter_ok(cm1.start_default_acceptors());
         assert!(cm1_eps.len() >= 1);
 
-        temp_configs.push(make_temp_config(cm1.get_beacon_acceptor_port()));
+        temp_configs.push(make_temp_config());
 
         let (cm2_i, cm2_o) = channel();
         let mut cm2 = Service::new(cm2_i).unwrap();
@@ -705,12 +693,12 @@ mod test {
             })
         };
 
-        let mut temp_configs = vec![make_temp_config(None)];
+        let mut temp_configs = vec![make_temp_config()];
 
         let (cm1_i, cm1_o) = channel();
         let cm1 = Service::new_inactive(cm1_i).unwrap();
 
-        temp_configs.push(make_temp_config(cm1.get_beacon_acceptor_port()));
+        temp_configs.push(make_temp_config());
 
         let (cm2_i, cm2_o) = channel();
         let cm2 = Service::new_inactive(cm2_i).unwrap();
@@ -845,7 +833,7 @@ mod test {
     fn connection_manager_start() {
         BootstrapHandler::cleanup().unwrap();
 
-        let _temp_config = make_temp_config(None);
+        let _temp_config = make_temp_config();
 
         let (cm_tx, cm_rx) = channel();
 
@@ -870,7 +858,7 @@ mod test {
         });
 
         let _ = spawn(move || {
-            let _temp_config = make_temp_config(None);
+            let _temp_config = make_temp_config();
             let (cm_aux_tx, cm_aux_rx) = channel();
             let cm_aux = Service::new_inactive(cm_aux_tx).unwrap();
             // setting the listening port to be greater than 4455 will make the test hanging

--- a/src/state.rs
+++ b/src/state.rs
@@ -111,13 +111,14 @@ impl State {
 
     pub fn populate_bootstrap_contacts(&mut self,
                                        config: &Config,
-                                       beacon_guid_and_port: &Option<([u8; 16], u16)>)
+                                       beacon_port: Option<u16>,
+                                       own_beacon_guid_and_port: &Option<([u8; 16], u16)>)
             -> Vec<Endpoint> {
         if config.override_default_bootstrap {
             return config.hard_coded_contacts.clone();
         }
 
-        let cached_contacts = if beacon_guid_and_port.is_some() {
+        let cached_contacts = if own_beacon_guid_and_port.is_some() {
             // this node "owns" bootstrap file
             let mut contacts = Vec::<Endpoint>::new();
             if let Some(ref mut handler) = self.bootstrap_handler {
@@ -128,9 +129,9 @@ impl State {
             vec![]
         };
 
-        let beacon_guid = beacon_guid_and_port.map(|(guid, _)| guid);
+        let beacon_guid = own_beacon_guid_and_port.map(|(guid, _)| guid);
 
-        let beacon_discovery = match config.beacon_port {
+        let beacon_discovery = match beacon_port {
             Some(port) => Self::seek_peers(beacon_guid, port),
             None => vec![]
         };

--- a/src/state.rs
+++ b/src/state.rs
@@ -52,7 +52,7 @@ pub struct State {
     pub cmd_receiver        : Receiver<Closure>,
     pub connections         : HashMap<Connection, ConnectionData>,
     pub listening_ports     : HashSet<Port>,
-    pub bootstrap_handler   : Option<BootstrapHandler>,
+    pub bootstrap_handler   : BootstrapHandler,
     pub stop_called         : bool,
     pub is_bootstrapping    : bool,
     pub next_punch_sequence : SequenceNumber,
@@ -70,7 +70,7 @@ impl State {
             cmd_receiver        : cmd_receiver,
             connections         : HashMap::new(),
             listening_ports     : HashSet::new(),
-            bootstrap_handler   : None,
+            bootstrap_handler   : BootstrapHandler::new(),
             stop_called         : false,
             is_bootstrapping    : false,
             next_punch_sequence : SequenceNumber::new(::rand::random()),
@@ -93,10 +93,7 @@ impl State {
 
     pub fn update_bootstrap_contacts(&mut self,
                                      new_contacts: Vec<Endpoint>) {
-        if let Some(ref mut bs) = self.bootstrap_handler {
-            // TODO: What was the second arg supposed to be?
-            let _ = bs.update_contacts(new_contacts, Vec::<Endpoint>::new());
-        }
+        let _ = self.bootstrap_handler.update_contacts(new_contacts, vec![]);
     }
 
     pub fn get_accepting_endpoints(&self) -> Vec<Endpoint> {
@@ -118,16 +115,7 @@ impl State {
             return config.hard_coded_contacts.clone();
         }
 
-        let cached_contacts = if own_beacon_guid_and_port.is_some() {
-            // this node "owns" bootstrap file
-            let mut contacts = Vec::<Endpoint>::new();
-            if let Some(ref mut handler) = self.bootstrap_handler {
-                contacts = handler.read_file().unwrap_or(vec![]);
-            }
-            contacts
-        } else {
-            vec![]
-        };
+        let cached_contacts = self.bootstrap_handler.read_file().unwrap_or(vec![]);
 
         let beacon_guid = own_beacon_guid_and_port.map(|(guid, _)| guid);
 
@@ -211,20 +199,16 @@ impl State {
         Self::handle_handshake(handshake, try!(transport::accept(acceptor)))
     }
 
-    pub fn handle_connect(&mut self,
-                          token                 : u32,
-                          handshake             : Handshake,
-                          trans                 : transport::Transport,
-                          is_broadcast_acceptor : bool) -> io::Result<Connection> {
+    pub fn handle_connect(&mut self, token: u32, handshake: Handshake,
+                          trans: transport::Transport)
+                          -> io::Result<Connection> {
         let c = trans.connection_id.clone();
         let event = Event::OnConnect(Ok(c), token);
 
         let connection = self.register_connection(handshake, trans, event);
-        if is_broadcast_acceptor {
-            if let Ok(ref connection) = connection {
-                let contacts = vec![connection.peer_endpoint()];
-                self.update_bootstrap_contacts(contacts);
-            }
+        if let Ok(ref connection) = connection {
+            let contacts = vec![connection.peer_endpoint()];
+            self.update_bootstrap_contacts(contacts);
         }
         connection
     }
@@ -236,8 +220,7 @@ impl State {
                                      -> io::Result<Connection> {
         let c = trans.connection_id.clone();
         let event = Event::OnRendezvousConnect(Ok(c), token);
-        let connection = self.register_connection(handshake, trans, event);
-        connection
+        self.register_connection(handshake, trans, event)
     }
 
     fn register_connection(&mut self,
@@ -349,8 +332,7 @@ impl State {
 
     pub fn bootstrap_off_list(&mut self,
                               token: u32,
-                              mut bootstrap_list: Vec<Endpoint>,
-                              is_broadcast_acceptor: bool) {
+                              mut bootstrap_list: Vec<Endpoint>) {
         if self.is_bootstrapping { return; }
         self.is_bootstrapping = true;
 
@@ -385,10 +367,10 @@ impl State {
                 state.is_bootstrapping = false;
 
                 if let Ok(c) = connect_result {
-                    let _ = state.handle_connect(token, c.0, c.1, is_broadcast_acceptor);
+                    let _ = state.handle_connect(token, c.0, c.1);
                 }
 
-                state.bootstrap_off_list(token, bootstrap_list, is_broadcast_acceptor);
+                state.bootstrap_off_list(token, bootstrap_list);
             }));
         });
     }
@@ -494,7 +476,7 @@ mod test {
         let cmd_sender = s.cmd_sender.clone();
 
         cmd_sender.send(Box::new(move |s: &mut State| {
-            s.bootstrap_off_list(0, eps, false);
+            s.bootstrap_off_list(0, eps);
         })).unwrap();
 
         let accept_thread = thread::spawn(move || {


### PR DESCRIPTION
- Don't start beaconing implicitly anylonger.
- Eliminate options related to beaconing from config file.

API changes follow from these changes.

Still to do:

- `state::populate_bootstrap_contacts` should use another mechanism to
  detect availability of the bootstrap cache file.
- Now beacon isn't always used, so we cannot rely on the beacon port
  ownership to elect the process that should own the cache file.
- Should we allow beacon run on multiple ports? Maybe the answer should
  change now.

Update #419

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/422)
<!-- Reviewable:end -->
