### PR TITLE
Fix rust-utp usage.

### DIFF
--- a/src/utp_wrapper.rs
+++ b/src/utp_wrapper.rs
@@ -31,6 +31,7 @@ impl UtpWrapper {
             loop {
                 let mut buf = [0; BUFFER_SIZE];
                 match socket.recv_from(&mut buf) {
+                    Ok((0, _src)) => break,
                     Ok((amt, _src)) => {
                         let buf = &buf[..amt];
                         let _ = itx.send(Vec::from(buf));


### PR DESCRIPTION
Rust's `std::io::Read` trait uses a 0-bytes read to signalize EOF[1].
rust-utp also follows this design.

[1] http://doc.rust-lang.org/nightly/std/io/trait.Read.html#tymethod.read

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/429)

<!-- Reviewable:end -->
