### PR TITLE
Fix simple_sender and simple_receiver examples.

### DIFF
--- a/examples/simple_receiver.rs
+++ b/examples/simple_receiver.rs
@@ -57,8 +57,11 @@ fn main() {
     let event_sender = ::maidsafe_utilities::event_sender::MaidSafeObserver::new(channel_sender,
                                                                                  crust_event_category,
                                                                                  category_tx);
-    let service = ::crust::Service::new(event_sender)
-        .unwrap();
+    let mut service = unwrap_result!(::crust::Service::new(event_sender));
+    match service.start_beacon(5484) {
+        Ok(_)  => (),
+        Err(e) => println!("Warning: Couldn't start beacon: {}. (perhaps another crust instance is using the port?)", e),
+    };
 
     println!("Run the simple_sender example in another terminal to send messages to this node.");
 

--- a/examples/simple_sender.rs
+++ b/examples/simple_sender.rs
@@ -47,7 +47,7 @@ fn main() {
                                                                                  crust_event_category,
                                                                                  category_tx);
 
-    let mut service = ::crust::Service::new(event_sender).unwrap();
+    let mut service = unwrap_result!(::crust::Service::new(event_sender));
 
     let (bs_sender, bs_receiver) = ::std::sync::mpsc::channel();
     // Start a thread running a loop which will receive and display responses from the peer.
@@ -88,7 +88,8 @@ fn main() {
         println!("Stopped receiving.");
     });
 
-    service.bootstrap(0, None);
+    let _ = service.start_beacon(5484);
+    service.bootstrap(0, Some(5484));
 
     println!("Service trying to bootstrap off node listening on TCP port 8888 \
               and UDP broadcast port 5484");


### PR DESCRIPTION
Disabling the beacon from starting automatically caused these examples to stop working. Beacon is now started manually in both examples.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/449)

<!-- Reviewable:end -->
