### PR TITLE
Bootstrap blacklist and remove contact from bootstrap cache

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -169,11 +169,27 @@ impl Service {
     /// New bootstrap connections will be notified by `NewBootstrapConnection` event.
     /// Its upper layer's responsibility to maintain or drop these connections.
     pub fn bootstrap(&mut self, token: u32, beacon_port: Option<u16>) {
+        self.bootstrap_with_blacklist(token, beacon_port, &[])
+    }
+
+    /// Same as bootstrap, but allows to specify a blacklist of endpoints
+    /// this service should never connect to.
+    pub fn bootstrap_with_blacklist(&mut self, token: u32,
+                                               beacon_port: Option<u16>,
+                                               blacklist: &[Endpoint])
+    {
         let config = self.config.clone();
         let beacon_guid_and_port = self.beacon_guid_and_port.clone();
+        let blacklist = blacklist.to_vec();
 
         Self::post(&self.cmd_sender, move |state : &mut State| {
-            let contacts = state.populate_bootstrap_contacts(&config, beacon_port, &beacon_guid_and_port);
+            let mut contacts = state.populate_bootstrap_contacts(
+                                    &config,
+                                    beacon_port,
+                                    &beacon_guid_and_port);
+
+            contacts.retain(|endpoint| !blacklist.contains(&endpoint));
+
             state.bootstrap_off_list(token, contacts.clone());
         });
     }
@@ -472,25 +488,24 @@ impl Drop for Service {
 #[cfg(test)]
 mod test {
     use super::*;
-    use transport::Endpoint;
-    use connection::Connection;
-    use std::thread::spawn;
-    use std::thread;
-    use std::sync::mpsc::{Sender, Receiver, channel};
+    use std::fs::remove_file;
+    use std::io;
     use std::net::{UdpSocket, Ipv4Addr, SocketAddrV4};
+    use std::path::PathBuf;
+    use std::sync::mpsc::{Sender, Receiver, channel};
+    use std::thread;
+    use std::thread::spawn;
     use rustc_serialize::{Decodable, Encodable};
     use cbor::{Decoder, Encoder};
-    use transport::Port;
+    use connection::Connection;
+    use transport::{Endpoint, Port};
     use config_handler::write_config_file;
-    use std::path::PathBuf;
-    use std::fs::remove_file;
     use event::Event;
-    use std::io;
     use util;
     use bootstrap_handler::BootstrapHandler;
+    use maidsafe_utilities::event_sender::{MaidSafeEventCategory, MaidSafeObserver};
 
-    type CategoryRx = ::std::sync::mpsc::Receiver<::maidsafe_utilities
-                                                  ::event_sender::MaidSafeEventCategory>;
+    type CategoryRx = ::std::sync::mpsc::Receiver<MaidSafeEventCategory>;
 
     fn encode<T>(value: &T) -> Bytes where T: Encodable
     {
@@ -540,8 +555,12 @@ mod test {
     }
 
     fn make_temp_config() -> TestConfigFile {
-        let path = write_config_file(Some(vec![]))
-            .unwrap();
+        make_temp_config_with_endpoints(&[])
+    }
+
+    fn make_temp_config_with_endpoints(endpoints: &[Endpoint]) -> TestConfigFile
+    {
+        let path = write_config_file(Some(endpoints.to_vec())).unwrap();
         TestConfigFile{path: path}
     }
 
@@ -562,10 +581,10 @@ mod test {
         let (cm1_i, _) = channel();
         let _config_file = make_temp_config();
 
-        let crust_event_category = ::maidsafe_utilities::event_sender::MaidSafeEventCategory::CrustEvent;
-        let event_sender1 = ::maidsafe_utilities::event_sender::MaidSafeObserver::new(cm1_i,
-                                                                                      crust_event_category.clone(),
-                                                                                      category_tx.clone());
+        let crust_event_category = MaidSafeEventCategory::CrustEvent;
+        let event_sender1 = MaidSafeObserver::new(cm1_i,
+                                                  crust_event_category.clone(),
+                                                  category_tx.clone());
 
         let mut cm1 = Service::new(event_sender1).unwrap();
         let cm1_ports = filter_ok(vec![cm1.start_accepting(Port::Tcp(0))]);
@@ -577,9 +596,9 @@ mod test {
         let _config_file = make_temp_config();
 
         let (cm2_i, cm2_o) = channel();
-        let event_sender2 = ::maidsafe_utilities::event_sender::MaidSafeObserver::new(cm2_i,
-                                                                                      crust_event_category,
-                                                                                      category_tx);
+        let event_sender2 = MaidSafeObserver::new(cm2_i,
+                                                  crust_event_category,
+                                                  category_tx);
         let mut cm2 = Service::new(event_sender2).unwrap();
 
         cm2.bootstrap(0, Some(beacon_port));
@@ -605,6 +624,80 @@ mod test {
     }
 
     #[test]
+    fn bootstrap_with_blacklist() {
+        BootstrapHandler::cleanup().unwrap();
+
+        let (ignored_category_tx, _) = channel();
+        let (ignored_event_tx, _) = channel();
+
+        let (category_tx, category_rx) = channel();
+        let (event_tx, event_rx) = channel();
+
+        let event_sender0 = MaidSafeObserver::new(
+                                ignored_event_tx.clone(),
+                                MaidSafeEventCategory::CrustEvent,
+                                ignored_category_tx.clone());
+
+        let event_sender1 = MaidSafeObserver::new(
+                                ignored_event_tx,
+                                MaidSafeEventCategory::CrustEvent,
+                                ignored_category_tx);
+
+        let event_sender2 = MaidSafeObserver::new(
+                                event_tx,
+                                MaidSafeEventCategory::CrustEvent,
+                                category_tx);
+
+        // Start accepting on these two services and keep their endpoints.
+        let mut service0 = Service::new(event_sender0).unwrap();
+        let mut service1 = Service::new(event_sender1).unwrap();
+
+        let endpoint0 = service0.start_accepting(Port::Tcp(0)).unwrap();
+        let endpoint1 = service1.start_accepting(Port::Tcp(0)).unwrap();
+
+        // Write those endpoints to the config file, so the next service will
+        // try to connect to them.
+        let _config_file = make_temp_config_with_endpoints(&[endpoint0,
+                                                             endpoint1]);
+
+        // Bootstrap another service but blacklist one of the endpoints in the
+        // config file.
+        let blacklisted_endpoint = endpoint0;
+        let mut service2 = Service::new(event_sender2).unwrap();
+        service2.bootstrap_with_blacklist(0, None, &[blacklisted_endpoint]);
+
+        let mut connected_endpoints = Vec::new();
+
+        for category in category_rx.iter() {
+            match category {
+                MaidSafeEventCategory::CrustEvent => {
+                    match event_rx.try_recv() {
+                        Ok(Event::BootstrapFinished) => break,
+                        Ok(Event::OnConnect(Ok((_, conn)), _)) => {
+                            connected_endpoints.push(conn.peer_endpoint());
+                        },
+                        event => println!("event: {:?}", event),
+                    }
+                },
+
+                _ => unreachable!("This category should not have been fired - {:?}", category),
+            }
+        }
+
+        // Test that the third service did not connect to the blacklisted
+        // endpoints.
+        //
+        // (comparing only ports here, because the
+        // blacklisted_endpoint's address is unspecified (0.0.0.0) but the
+        // endpoints gathered from the OnConnect events have concrete addresses.
+        assert!(!connected_endpoints.is_empty());
+
+        for endpoint in connected_endpoints {
+            assert!(endpoint.get_port() != blacklisted_endpoint.get_port());
+        }
+    }
+
+    #[test]
     fn connection_manager() {
         BootstrapHandler::cleanup().unwrap();
 
@@ -612,7 +705,7 @@ mod test {
             spawn(move || {
                 for it in category_rx.iter() {
                     match it {
-                        ::maidsafe_utilities::event_sender::MaidSafeEventCategory::CrustEvent => {
+                        MaidSafeEventCategory::CrustEvent => {
                             if let Ok(event) = o.try_recv() {
                                 match event {
                                     Event::OnConnect(Ok((_, other_ep)), _) => {
@@ -638,10 +731,10 @@ mod test {
 
         let (category_tx, category_rx0) = channel();
         let (cm1_i, cm1_o) = channel();
-        let crust_event_category = ::maidsafe_utilities::event_sender::MaidSafeEventCategory::CrustEvent;
-        let event_sender1 = ::maidsafe_utilities::event_sender::MaidSafeObserver::new(cm1_i,
-                                                                                      crust_event_category.clone(),
-                                                                                      category_tx);
+        let crust_event_category = MaidSafeEventCategory::CrustEvent;
+        let event_sender1 = MaidSafeObserver::new(cm1_i,
+                                                  crust_event_category.clone(),
+                                                  category_tx);
         let mut cm1 = Service::new(event_sender1).unwrap();
         let cm1_eps = filter_ok(vec![cm1.start_accepting(Port::Tcp(0))]);
         assert!(cm1_eps.len() >= 1);
@@ -650,9 +743,9 @@ mod test {
 
         let (cm2_i, cm2_o) = channel();
         let (category_tx, category_rx1) = channel();
-        let event_sender2 = ::maidsafe_utilities::event_sender::MaidSafeObserver::new(cm2_i,
-                                                                                      crust_event_category,
-                                                                                      category_tx);
+        let event_sender2 = MaidSafeObserver::new(cm2_i,
+                                                  crust_event_category,
+                                                  category_tx);
         let mut cm2 = Service::new(event_sender2).unwrap();
         let cm2_eps = filter_ok(vec![cm2.start_accepting(Port::Tcp(0))]);
         assert!(cm2_eps.len() >= 1);

--- a/src/state.rs
+++ b/src/state.rs
@@ -95,8 +95,11 @@ impl State {
     }
 
     pub fn update_bootstrap_contacts(&mut self,
-                                     new_contacts: Vec<Endpoint>) {
-        let _ = self.bootstrap_handler.update_contacts(new_contacts, vec![]);
+                                     contacts_to_add: Vec<Endpoint>,
+                                     contacts_to_remove: Vec<Endpoint>)
+    {
+        let _ = self.bootstrap_handler.update_contacts(contacts_to_add,
+                                                       contacts_to_remove);
     }
 
     pub fn get_accepting_endpoints(&self) -> Vec<Endpoint> {
@@ -212,7 +215,7 @@ impl State {
         let connection = self.register_connection(handshake, trans, event);
         if let Ok(ref connection) = connection {
             let contacts = vec![connection.peer_endpoint()];
-            self.update_bootstrap_contacts(contacts);
+            self.update_bootstrap_contacts(contacts, vec![]);
         }
         connection
     }


### PR DESCRIPTION
- Add new method `Service::bootstrap_with_blacklist` which allows to specify list of endpoints the service would not attempt to connect to. `Service::bootstrap` now just calls `bootstrap_with_blacklist` passing empty blacklist.
- Add new method `Service::remove_bootstrap_contact` to remove a contact (endpoint) from bootstrap cache. Decided to call it `remove_bootstrap_contact` instead of `remove_from_bootstrap_cache` to remain consistent with the current naming convention in `Service` and `State`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/459)
<!-- Reviewable:end -->
