### PR TITLE
stop adding our own interface addresses to our bootstrap contact list

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -32,7 +32,6 @@ use itertools::Itertools;
 use acceptor::Acceptor;
 use beacon;
 use config_handler::{Config, read_config_file};
-use get_if_addrs::get_if_addrs;
 use transport::Handshake;
 use transport;
 use endpoint::{Endpoint, Protocol};
@@ -146,17 +145,6 @@ impl Service {
                                           hole_punch_server,
                                           self.connection_map.clone()));
         self.acceptors.push(acceptor);
-
-        // TODO Take this out after evaluating
-        if self.beacon_guid_and_port.is_some() {
-            let contacts = try!(get_if_addrs())
-                               .into_iter()
-                               .filter(|i| !i.is_loopback())
-                               .map(|i| Endpoint::new(Protocol::Utp, i.ip(), accept_addr.port()))
-                               .collect();
-
-            try!(self.bootstrap_handler.update_contacts(contacts, vec![]));
-        }
 
         // FIXME: Instead of hardcoded wrapping in loopback V4, the
         // acceptor should tell us the address it is accepting on.


### PR DESCRIPTION
This code was first introduced in commit
8fb669c5e0b2d3a2d119202e5b8f999a19c1f65c (src/connection_manager.rs:102):

```
pub fn start_listening(&mut self, hint: Vec<Port>, beacon_port: Option<u16>) -> IoResult<(Vec<Endpoint>, Option<u16>)> {
let end_points = hint.iter().filter_map(|port| self.listen(port).ok()).collect::<Vec<_>>();

// ...

let mut contacts = BootStrapContacts::new();
for end_point in &end_points {
    contacts.push(Contact::new(end_point.clone(), public_key.clone()));
}
let mut bootstrap_handler = BootStrapHandler::new();
bootstrap_handler.add_bootstrap_contacts(contacts); // < HERE!!!
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/483)

<!-- Reviewable:end -->
