### PR TITLE
Remove bootstrap_connect function.

### DIFF
--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -54,7 +54,7 @@ use std::time::Duration;
 
 use crust::SocketAddr;
 use crust::{Service, Protocol, Endpoint, Connection};
-use crust::{OurContactInfo, TheirContactInfo};
+use crust::{HolePunchServer, OurContactInfo, TheirContactInfo};
 
 static USAGE: &'static str = "
 Usage:
@@ -451,6 +451,9 @@ fn main() {
         unwrap_result!(create_local_config());
     }
 
+    let (tx, _rx) = channel();
+    let hole_punch_server = Arc::new(unwrap_result!(HolePunchServer::start(tx)));
+
     let mut stdout = term::stdout();
     let mut stdout_copy = term::stdout();
 
@@ -627,7 +630,7 @@ fn main() {
             match cmd {
                 UserCommand::Connect(ep) => {
                     println!("Bootstrap connecting to {:?}", ep);
-                    service.bootstrap_connect(0, vec![ep]);
+                    service.bootstrap_off_list(0, vec![ep], hole_punch_server.clone());
                 }
                 UserCommand::ConnectRendezvous(udp_id, endpoint) => {
                     let mut network = network.lock().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub use endpoint::{Endpoint, Protocol};
 pub use connection::Connection;
 pub use util::ifaddrs_if_unspecified;
 pub use socket_addr::SocketAddr;
+pub use hole_punching::HolePunchServer;
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
Users wanting to connect to other peers must either use connect() to perform a rendezvous connect or bootstrap_off_list.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/487)
<!-- Reviewable:end -->
