### PR TITLE
update crust_peer example

### DIFF
--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -36,6 +36,8 @@ extern crate docopt;
 extern crate rand;
 extern crate term;
 extern crate time;
+extern crate sodiumoxide;
+extern crate cbor;
 
 use docopt::Docopt;
 use rand::random;
@@ -45,15 +47,18 @@ use std::cmp;
 use std::sync::mpsc::channel;
 use std::sync::mpsc::Sender;
 use std::io;
-use crust::error::Error;
 use std::net;
 use std::str::FromStr;
 use std::thread;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use std::collections::{BTreeMap, HashMap};
+use std::fs::File;
 
-use crust::{Service, Protocol, Endpoint, Connection, SocketAddr};
-use crust::{HolePunchServer, OurContactInfo, TheirContactInfo};
+use crust::{Service, Protocol, Endpoint, Connection, ConnectionInfoResult,
+            SocketAddr, OurConnectionInfo, TheirConnectionInfo};
+
+use sodiumoxide::crypto::sign::ed25519::PublicKey;
 
 static USAGE: &'static str = "
 Usage:
@@ -91,12 +96,6 @@ will be chosen.
 
 \
                               Options:
-  -c, --create-local-config  Tries to create a default \
-                              config file in the same
-                             directory as \
-                              this executable.  Won't overwrite an
-                             \
-                              existing file.
   -s RATE, --speed=RATE      Keep sending random \
                               data at a maximum speed of RATE
                              \
@@ -109,7 +108,6 @@ const BEACON_PORT: u16 = 5484;
 
 #[derive(RustcDecodable, Debug)]
 struct Args {
-    flag_create_local_config: bool,
     flag_speed: Option<u64>,
     flag_help: bool,
 }
@@ -124,106 +122,13 @@ fn generate_random_vec_u8(size: usize) -> Vec<u8> {
 
 /// /////////////////////////////////////////////////////////////////////////////
 ///
-/// CrustNode
-///
-/// /////////////////////////////////////////////////////////////////////////////
-#[derive(Clone)]
-struct CrustNode {
-    pub connection_id: Connection,
-    pub connected: bool,
-}
-
-impl CrustNode {
-    pub fn new(connection_id: Connection, connected: bool) -> CrustNode {
-        CrustNode {
-            connection_id: connection_id,
-            connected: connected,
-        }
-    }
-}
-
-/*
-/// /////////////////////////////////////////////////////////////////////////////
-///
-/// UdpData
-///
-/// /////////////////////////////////////////////////////////////////////////////
-struct UdpData {
-    stopped: Arc<Mutex<bool>>,
-    socket: UdpSocket,
-    external_endpoints: HashSet<SocketAddr>,
-    receiver_join_handle: Option<thread::JoinHandle<()>>,
-}
-
-impl UdpData {
-    pub fn new(socket: UdpSocket, ext_eps: HashSet<SocketAddr>) -> UdpData {
-        use std::io::ErrorKind::{TimedOut, WouldBlock, Interrupted};
-
-        let stopped = Arc::new(Mutex::new(false));
-        let stopped_copy = stopped.clone();
-        let socket_copy = socket.try_clone().unwrap();
-
-        let join_handle = thread::spawn(move || {
-            let mut buf = [0u8; 256];
-            let timeout = ::std::time::Duration::from_millis(100);
-            assert!(socket.set_read_timeout(Some(timeout)).is_ok());
-            loop {
-                {
-                    let stopped = stopped.lock().unwrap();
-                    if *stopped {
-                        break;
-                    }
-                }
-
-                match socket.recv_from(&mut buf) {
-                    Ok(_x) => {
-                        println!("UdpSocket received data");
-                    }
-                    Err(e) => {
-                        match e.kind() {
-                            TimedOut | WouldBlock => continue,
-                            Interrupted => (),
-                            _ => break,
-                        }
-                    }
-                }
-            }
-        });
-
-        UdpData {
-            stopped: stopped_copy,
-            socket: socket_copy,
-            external_endpoints: ext_eps,
-            receiver_join_handle: Some(join_handle),
-        }
-    }
-
-    pub fn send_to(&self, destination: SocketAddr) {
-        let buf = [0u8; 256];
-        assert!(self.socket.send_to(&buf, &*destination).is_ok());
-    }
-}
-
-impl Drop for UdpData {
-    fn drop(&mut self) {
-        {
-            let mut stopped = self.stopped.lock().unwrap();
-            *stopped = true;
-        }
-        let join_handle = self.receiver_join_handle.take();
-        assert!(join_handle.unwrap().join().is_ok());
-    }
-}
-*/
-
-/// /////////////////////////////////////////////////////////////////////////////
-///
 /// Network
 ///
 /// /////////////////////////////////////////////////////////////////////////////
 struct Network {
-    crust_nodes: Vec<CrustNode>,
-    our_contact_infos: Vec<OurContactInfo>,
+    nodes: HashMap<PublicKey, Connection>,
+    our_contact_infos: BTreeMap<u32, String>,
+    ready_contact_infos: HashMap<String, OurConnectionInfo>,
     performance_start: time::SteadyTime,
     performance_interval: time::Duration,
     received_msgs: u32,
@@ -234,8 +139,9 @@ struct Network {
 impl Network {
     pub fn new() -> Network {
         Network {
-            crust_nodes: Vec::new(),
-            our_contact_infos: Vec::new(),
+            nodes: HashMap::new(),
+            our_contact_infos: BTreeMap::new(),
+            ready_contact_infos: HashMap::new(),
             performance_start: time::SteadyTime::now(),
             performance_interval: time::Duration::seconds(10),
             received_msgs: 0,
@@ -243,70 +149,36 @@ impl Network {
         }
     }
 
-    // Will add node if not duplicated.  Returns true when added.
-    pub fn add_node(&mut self, new_node: CrustNode) -> bool {
-        if self.crust_nodes
-               .iter()
-               .filter(|node| node.connection_id == new_node.connection_id)
-               .count() == 0 {
-            self.crust_nodes.push(new_node);
-            return true;
-        }
-        for node in self.crust_nodes
-                        .iter_mut()
-                        .filter(|node| node.connection_id == new_node.connection_id) {
-            node.connected = true;
-        }
-        return false;
-    }
-
-    pub fn release_our_contact_info(&mut self, id: usize) -> Option<OurContactInfo> {
-        if id >= self.our_contact_infos.len() {
-            return None;
-        }
-        Some(self.our_contact_infos.remove(id))
-    }
-
-    pub fn drop_node(&mut self, lost_node: Connection) {
-        for node in self.crust_nodes.iter_mut().filter(|node| node.connection_id == lost_node) {
-            node.connected = false;
-        }
-    }
-
     pub fn print_connected_nodes(&self) {
-        println!("Node count: {}", self.crust_nodes.len());
-        for (i, node) in self.crust_nodes.iter().enumerate() {
-            let status = if node.connected {
+        println!("Node count: {}", self.nodes.len());
+        for (i, (id, node)) in self.nodes.iter().enumerate() {
+            let status = if !node.is_closed() {
                 "Connected   "
             } else {
                 "Disconnected"
             };
 
-            println!("    [{}] {} {:?}", i, status, node.connection_id);
-        }
-
-        println!("\nOur contact infocount: {}", self.our_contact_infos.len());
-        for (i, contact_info) in self.our_contact_infos.iter().enumerate() {
-            println!("    [{}] {:?} (static: {:?}) (rendezvous: {:?})",
-                     i,
-                     contact_info.socket.local_addr().unwrap(),
-                     contact_info.static_addrs,
-                     contact_info.rendezvous_addrs);
+            println!("    [{}] {} {:?}", i, status, id);
         }
 
         println!("");
     }
 
     pub fn remove_disconnected_nodes(&mut self) {
-        self.crust_nodes.retain(|node| node.connected);
+        let to_remove = self.nodes.iter().filter_map(|(id, node)| {
+            if node.is_closed() {
+                Some(id.clone())
+            } else {
+                None
+            }
+        }).collect::<Vec<_>>();
+        for id in to_remove {
+            let _ = self.nodes.remove(&id);
+        }
     }
 
-    pub fn get(&self, n: usize) -> Option<&CrustNode> {
-        self.crust_nodes.get(n)
-    }
-
-    pub fn get_all(&self) -> &Vec<CrustNode> {
-        &self.crust_nodes
+    pub fn get_mut(&mut self, n: usize) -> Option<&mut Connection> {
+        self.nodes.iter_mut().skip(n).next().map(|(_, c)| c)
     }
 
     pub fn record_received(&mut self, msg_size: usize) {
@@ -392,66 +264,12 @@ fn on_time_out(timeout: Duration, flag_speed: bool) -> Sender<bool> {
     tx
 }
 
-fn create_local_config() -> Result<(), Error> {
-    let mut stdout = term::stdout();
-    let mut config_path = match ::crust::current_bin_dir() {
-        Ok(path) => path,
-        Err(error) => {
-            stdout = red_foreground(stdout);
-            println!("Failed to get config file path: {:?}", error);
-            let _ = reset_foreground(stdout);
-            std::process::exit(1);
-        }
-    };
-    let mut config_name = try!(::crust::exe_file_stem());
-    config_name.push(".crust.config");
-    config_path.push(config_name);
-
-    match ::std::fs::metadata(&config_path) {
-        Ok(_) => {
-            stdout = red_foreground(stdout);
-            println!("Failed to create {:?} since it already exists.",
-                     config_path);
-            let _ = reset_foreground(stdout);
-        }
-        Err(_) => {
-            // Continue if the file doesn't exist
-            // This test helper function will use defaults for each `None` value.
-            match ::crust::write_config_file(None) {
-                Ok(file_path) => {
-                    stdout = green_foreground(stdout);
-                    println!("Created default config file at {:?}.", file_path);
-                    let _ = reset_foreground(stdout);
-                }
-                Err(error) => {
-                    stdout = red_foreground(stdout);
-                    println!("Failed to write default config file: {:?}", error);
-                    let _ = reset_foreground(stdout);
-                    std::process::exit(2);
-                }
-            }
-        }
-    };
-    Ok(())
-}
-
-fn filter_ok<T>(vec: Vec<Result<T, Error>>) -> Vec<T> {
-    vec.into_iter().filter_map(|a| a.ok()).collect()
-}
-
 fn main() {
     ::maidsafe_utilities::log::init(true);
 
     let args: Args = Docopt::new(USAGE)
                          .and_then(|docopt| docopt.decode())
                          .unwrap_or_else(|error| error.exit());
-
-    if args.flag_create_local_config {
-        unwrap_result!(create_local_config());
-    }
-
-    let (tx, _rx) = channel();
-    let hole_punch_server = Arc::new(unwrap_result!(HolePunchServer::start(tx)));
 
     let mut stdout = term::stdout();
     let mut stdout_copy = term::stdout();
@@ -467,20 +285,7 @@ fn main() {
         ::maidsafe_utilities::event_sender::MaidSafeObserver::new(channel_sender,
                                                                   crust_event_category,
                                                                   category_tx);
-    let mut service = Service::new(event_sender).unwrap();
-    let listening_ports = filter_ok(vec![service.start_accepting(0)]);
-    assert!(listening_ports.len() >= 1);
-    let _ = service.start_beacon(BEACON_PORT);
-
-    stdout = green_foreground(stdout);
-    print!("Listening on ports");
-    for port in &listening_ports {
-        print!(" {:?}", *port);
-    }
-    println!("");
-
-    stdout = reset_foreground(stdout);
-    service.bootstrap(0, Some(BEACON_PORT));
+    let mut service = Service::new(event_sender, BEACON_PORT).unwrap();
 
     let network = Arc::new(Mutex::new(Network::new()));
     let network2 = network.clone();
@@ -502,55 +307,53 @@ fn main() {
                                 let mut network = network2.lock().unwrap();
                                 network.record_received(message_length);
                                 println!("\nReceived from {:?} message: {}",
-                                         connection.peer_endpoint(),
+                                         connection,
                                          String::from_utf8(bytes)
                                          .unwrap_or(format!("non-UTF-8 message of {} bytes",
                                                             message_length)));
                             },
-                            crust::Event::OnBootstrapConnect(Ok((_, connection)), _) |
-                            crust::Event::OnConnect(Ok((_, connection)), _) => {
-                                stdout_copy = cyan_foreground(stdout_copy);
-                                println!("\nConnected to peer at {:?}", connection.peer_endpoint());
+                            crust::Event::ConnectionInfoPrepared(result) => {
+                                let ConnectionInfoResult {
+                                    result_token, result } = result;
                                 let mut network = network2.lock().unwrap();
-                                network.add_node(CrustNode::new(connection.clone(), true));
+                                let our_file = network.our_contact_infos
+                                    .remove(&result_token).unwrap();
+                                let info = match result {
+                                    Ok(i) => i,
+                                    Err(e) => {
+                                        println!("Failed to create {}\ncause: {}",
+                                                 our_file, e);
+                                        continue;
+                                    }
+                                };
+                                let file = File::create(&our_file).unwrap();
+                                let mut enc = cbor::Encoder::from_writer(file);
+                                enc.encode(::std::iter::once(&info.to_their_connection_info())).unwrap();
+                                let _ = network.ready_contact_infos.insert(our_file.clone(), info);
+                                drop(enc);
+                                println!("\n\"{}\" with our connection info is ready",
+                                         our_file);
+                            },
+                            crust::Event::NewBootstrapConnection{ connection, their_pub_key } |
+                            crust::Event::NewConnection{ connection: Ok(connection), their_pub_key } => {
+                                stdout_copy = cyan_foreground(stdout_copy);
+                                println!("\nConnected to peer at {:?}", their_pub_key);
+                                let mut network = network2.lock().unwrap();
+                                let _ = network.nodes.insert(their_pub_key.clone(), connection);
                                 network.print_connected_nodes();
                                 if !bootstrapped {
                                     bootstrapped = true;
-                                    let _ = bs_sender.send(connection.clone());
+                                    let _ = bs_sender.send(their_pub_key);
                                 }
-                            },
-                            crust::Event::OnBootstrapAccept(_, connection) => {
-                                stdout_copy = cyan_foreground(stdout_copy);
-                                println!("\nAccepted peer at {:?}", connection);
-                                let mut network = network2.lock().unwrap();
-                                network.add_node(CrustNode::new(connection.clone(), true));
-                                network.print_connected_nodes();
-                                if !bootstrapped {
-                                    bootstrapped = true;
-                                    let _ = bs_sender.send(connection);
-                                }
-                            },
-                            crust::Event::LostConnection(c) => {
+                            }
+                            crust::Event::LostConnection(pub_key) => {
                                 stdout_copy = yellow_foreground(stdout_copy);
-                                println!("\nLost connection to peer at {:?}", c);
+                                println!("\nLost connection to peer at {:?}",
+                                         pub_key);
                                 stdout_copy = cyan_foreground(stdout_copy);
                                 let mut network = network2.lock().unwrap();
-                                network.drop_node(c);
+                                let _ = network.nodes.remove(&pub_key);
                                 network.print_connected_nodes();
-                            },
-                            crust::Event::ContactInfoPrepared(content) => {
-                                match content.result {
-                                    Ok(contact_info) => {
-                                        println!("Received our contact info: {:?}", contact_info);
-                                        let mut network = network2.lock().unwrap();
-                                        network.our_contact_infos.push(contact_info);
-                                        network.print_connected_nodes();
-                                    },
-                                    Err(what) => {
-                                        println!("Preparing contact info failed: {} {:?}",
-                                                 content.result_token, what);
-                                    },
-                                }
                             }
                             e => {
                                 println!("\nReceived event {:?} (not handled)", e);
@@ -597,15 +400,16 @@ fn main() {
         let speed = args.flag_speed.unwrap();  // Safe due to `running_speed_test` == true
         let peer = connected_peer;
         let mut rng = rand::thread_rng();
+        let mut network = network.lock().unwrap();
         loop {
             let length = rng.gen_range(50, speed);
             let times = cmp::max(1, speed / length);
             let sleep_time = cmp::max(1, 1000 / times);
             for _ in 0..times {
-                service.send(peer.clone(), generate_random_vec_u8(length as usize));
+                network.nodes.get_mut(&peer).unwrap()
+                    .send(&generate_random_vec_u8(length as usize)[..]).unwrap();
                 debug!("Sent a message with length of {} bytes to {:?}",
-                       length,
-                       peer);
+                       length, peer);
                 std::thread::sleep(Duration::from_millis(sleep_time));
             }
         }
@@ -627,65 +431,39 @@ fn main() {
             };
 
             match cmd {
-                UserCommand::Connect(ep) => {
-                    println!("Bootstrap connecting to {:?}", ep);
-                    service.bootstrap_off_list(0, vec![ep], hole_punch_server.clone());
-                }
-                UserCommand::ConnectRendezvous(udp_id, endpoint) => {
+                UserCommand::PrepareConnectionInfo(our_file) => {
+                    let mut token = 0;
                     let mut network = network.lock().unwrap();
-                    let our_contact_info = match network.release_our_contact_info(udp_id) {
-                        Some(ci) => ci,
-                        None => {
-                            println!("No such contact info #{}", udp_id);
-                            continue;
-                        }
-                    };
-                    println!("ConnectingRendezvous with {} to {:?}", udp_id, endpoint);
-                    let their_contact_info = TheirContactInfo {
-                        secret: our_contact_info.secret,
-                        static_addrs: vec![],
-                        rendezvous_addrs: vec![endpoint.socket_addr().clone()],
-                    };
-                    service.connect(our_contact_info, their_contact_info, 0);
+                    while network.our_contact_infos.contains_key(&token) {
+                        token += 1;
+                    }
+                    let _ = network.our_contact_infos.insert(token, our_file);
+                    service.prepare_connection_info(token);
+                }
+                UserCommand::Connect(our_file, their_file) => {
+                    let mut network = network.lock().unwrap();
+                    let our_info = network.ready_contact_infos.remove(&our_file)
+                        .unwrap();
+                    let their_file = File::open(&their_file).unwrap();
+                    let their_info = cbor::Decoder::from_reader(their_file)
+                        .decode::<TheirConnectionInfo>().next().unwrap().unwrap();
+                    println!("Connecting to {:?}", their_info);
+                    service.connect(our_info, their_info);
                 }
                 UserCommand::Send(peer, message) => {
-                    let network = network.lock().unwrap();
-                    match network.get(peer) {
-                        Some(ref node) => {
-                            service.send(node.connection_id.clone(), message.into_bytes())
+                    let mut network = network.lock().unwrap();
+                    match network.get_mut(peer) {
+                        Some(ref mut node) => {
+                            node.send(&message.into_bytes()[..]).unwrap()
                         }
                         None => println!("Invalid connection #"),
                     }
                 }
-                /*
-                UserCommand::SendUdp(peer, dst, _message) => {
-                    let network = network.lock().unwrap();
-                    match network.get_our_contact_info(peer) {
-                        Some(ref ci) => ci.socket.send_to(dst),
-                        None => println!("Invalid udp #"),
-                    }
-                }
-                */
                 UserCommand::SendAll(message) => {
-                    let network = network.lock().unwrap();
-                    for node in network.get_all() {
-                        service.send(node.connection_id.clone(), message.clone().into_bytes());
+                    let mut network = network.lock().unwrap();
+                    for (_, node) in network.nodes.iter_mut() {
+                        node.send(&message.clone().into_bytes()[..]).unwrap();
                     }
-                }
-                /*
-                UserCommand::Punch(peer, dst) => {
-                    let network = network.lock().unwrap();
-                    match network.get_udp(peer) {
-                        Some(ref udp) => {
-                            let socket = udp.socket.try_clone().unwrap();
-                            service.udp_punch_hole(0, socket, None, dst);
-                        }
-                        None => println!("Invalid udp #"),
-                    }
-                }
-                */
-                UserCommand::Map => {
-                    service.prepare_contact_info(0);
                 }
                 UserCommand::List => {
                     let network = network.lock().unwrap();
@@ -715,20 +493,13 @@ fn main() {
 /// We'll use docopt to help parse the ongoing CLI commands entered by the user.
 static CLI_USAGE: &'static str = "
 Usage:
-  cli connect <endpoint>
-  cli connect-rendezvous \
-                                  <peer> <endpoint>
+  cli prepare-connection-info <our-file>
+  cli connect <our-file> <their-file>
   cli send <peer> <message>...
-  cli send-udp \
-                                  <peer> <destination> <message>...
   cli send-all <message>...
-  \
-                                  cli map
-  cli punch <peer> <destination>
   cli list
   cli clean
-  \
-                                  cli stop
+  cli stop
   cli help
 
 ";
@@ -736,62 +507,48 @@ Usage:
 fn print_usage() {
     static USAGE: &'static str = r#"\
 # Commands:
-    connect <endpoint>                            - Initiate a connection to the remote endpoint
-    connect-rendezvous <udp-socket-id> <endpoint> - As above, but using rendezvous connect
+    prepare-connection-info <our-file>            - Use existing connections to find our external
+    connect <our-file> <their-file>               - Initiate a connection to the remote endpoint
     send <connection-id> <message>                - Send a string to the given connection
-    send-udp <udp-socket-id> <message>            - E.g. send-udp 0 foo bar
     send-all <message>                            - Send a string to all connections
-    map                                           - Use existing connections to find our external
-                                                    IP address.  Also creates a UDP socket.
-    punch <udp-socket-id> <socketaddr>            - UDP hole punch with given socket to the given
-                                                    destination
     list                                          - List existing connections and UDP sockets
     clean                                         - Remove disconnected connections from the list
     stop                                          - Exit the app
     help                                          - Print this help
 
 # Where
-    <endpoint>      - Specifies transport and socket address.  Its form is
-                      [Tcp|Utp](a.b.c.d:p)
-                      E.g. Tcp(192.168.0.1:5483)
-    <udp-socket-id> - ID of a UDP socket as listed using the `list` command
+    <our-file>      - The file where we'll read/write our connection info
+    <their-file>    - The file where we'll read their connection info.
     <connection-id> - ID of a connection as listed using the `list` command
-    <socketaddr>    - IP address and port.  E.g. 192.168.0.1:5483
 "#;
     println!("{}", USAGE);
 }
 
 #[derive(RustcDecodable, Debug)]
 struct CliArgs {
+    cmd_prepare_connection_info: bool,
     cmd_connect: bool,
-    cmd_connect_rendezvous: bool,
     cmd_send: bool,
-    cmd_send_udp: bool,
     cmd_send_all: bool,
-    cmd_map: bool,
-    cmd_punch: bool,
     cmd_list: bool,
     cmd_clean: bool,
     cmd_stop: bool,
     cmd_help: bool,
-    arg_endpoint: Option<PeerEndpoint>,
-    arg_destination: Option<::crust::SocketAddr>,
     arg_peer: Option<usize>,
     arg_message: Vec<String>,
+    arg_our_file: Option<String>,
+    arg_their_file: Option<String>,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 enum UserCommand {
     Stop,
-    Connect(Endpoint),
-    ConnectRendezvous(usize, Endpoint),
+    PrepareConnectionInfo(String),
+    Connect(String, String),
     Send(usize, String),
-    //SendUdp(usize, SocketAddr, String),
     SendAll(String),
-    //Punch(usize, SocketAddr),
     List,
     Clean,
-    Map,
 }
 
 fn parse_user_command(cmd: String) -> Option<UserCommand> {
@@ -815,31 +572,20 @@ fn parse_user_command(cmd: String) -> Option<UserCommand> {
     };
 
     if args.cmd_connect {
-        let peer = args.arg_endpoint.unwrap().addr;
-        Some(UserCommand::Connect(peer))
-    } else if args.cmd_connect_rendezvous {
-        let peer = args.arg_peer.unwrap();
-        let endpoint = args.arg_endpoint.unwrap().addr;
-        Some(UserCommand::ConnectRendezvous(peer, endpoint))
+        let our_file = args.arg_our_file.unwrap();
+        let their_file = args.arg_their_file.unwrap();
+        Some(UserCommand::Connect(our_file, their_file))
     } else if args.cmd_send {
         let peer = args.arg_peer.unwrap();
         let msg = args.arg_message.join(" ");
         Some(UserCommand::Send(peer, msg))
-    } /* else if args.cmd_send_udp {
-        let peer = args.arg_peer.unwrap();
-        let dst = args.arg_destination.unwrap();
-        let msg = args.arg_message.join(" ");
-        Some(UserCommand::SendUdp(peer, dst, msg))
-    } */ else if args.cmd_send_all {
+    } else if args.cmd_send_all {
         let msg = args.arg_message.join(" ");
         Some(UserCommand::SendAll(msg))
-    } else if args.cmd_map {
-        Some(UserCommand::Map)
-    } /* else if args.cmd_punch {
-        let peer = args.arg_peer.unwrap();
-        let dst = args.arg_destination.unwrap();
-        Some(UserCommand::Punch(peer, dst))
-    } */ else if args.cmd_list {
+    } else if args.cmd_prepare_connection_info {
+        let our_file = args.arg_our_file.unwrap();
+        Some(UserCommand::PrepareConnectionInfo(our_file))
+    } else if args.cmd_list {
         Some(UserCommand::List)
     } else if args.cmd_clean {
         Some(UserCommand::Clean)


### PR DESCRIPTION
now compiling against latest crust

However I was unable to connect two peers.

Output from peer 1:

```
vinipsmaker ~/Downloads/crust $ cargo run --example crust_peer
     Running `target/debug/examples/crust_peer`
\
# Commands:
    prepare-connection-info <our-file>            - Use existing connections to find our external
    connect <our-file> <their-file>               - Initiate a connection to the remote endpoint
    send <connection-id> <message>                - Send a string to the given connection
    send-all <message>                            - Send a string to all connections
    list                                          - List existing connections and UDP sockets
    clean                                         - Remove disconnected connections from the list
    stop                                          - Exit the app
    help                                          - Print this help

# Where
    <our-file>      - The file where we'll read/write our connection info
    <their-file>    - The file where we'll read their connection info.
    <connection-id> - ID of a connection as listed using the `list` command

> 
Received event BootstrapFinished (not handled)
prepare-connection-info 1
> 
"1" with our connection info is ready
connect 1 2
Connecting to TheirConnectionInfo { secret: [26, 1, 3, 104], static_contact_info: StaticContactInfo { pub_key: PublicKey([173, 208, 195, 212, 18, 44, 238, 66, 184, 163, 26, 19, 56, 188, 67, 51, 58, 15, 155, 37, 163, 41, 174, 155, 167, 120, 138, 146, 164, 165, 232, 132]), tcp_acceptors: [SocketAddr(V4(127.0.0.1:45223)), SocketAddr(V4(10.0.0.100:45223)), SocketAddr(V4(192.168.100.1:45223)), SocketAddr(V6([::1]:45223)), SocketAddr(V4(127.0.0.1:41939)), SocketAddr(V4(10.0.0.100:41939)), SocketAddr(V4(192.168.100.1:41939)), SocketAddr(V6([::1]:41939))], udp_listeners: [SocketAddr(V4(127.0.0.1:40933)), SocketAddr(V4(10.0.0.100:40933)), SocketAddr(V4(192.168.100.1:40933)), SocketAddr(V6([::1]:40933))] }, udp_addrs: [SocketAddr(V4(127.0.0.1:46867)), SocketAddr(V4(10.0.0.100:46867)), SocketAddr(V4(192.168.100.1:46867)), SocketAddr(V6([::1]:46867))], pub_key: PublicKey([173, 208, 195, 212, 18, 44, 238, 66, 184, 163, 26, 19, 56, 188, 67, 51, 58, 15, 155, 37, 163, 41, 174, 155, 167, 120, 138, 146, 164, 165, 232, 132]) }
> 
Received event NewConnection { connection: Err(Error { repr: Custom(Custom { kind: TimedOut, error: StringError("Timed out waiting for rendevous connection") }) }), their_pub_key: PublicKey([173, 208, 195, 212, 18, 44, 238, 66, 184, 163, 26, 19, 56, 188, 67, 51, 58, 15, 155, 37, 163, 41, 174, 155, 167, 120, 138, 146, 164, 165, 232, 132]) } (not handled)
```

Output from peer 2:

```
vinipsmaker ~/Downloads/crust $ cargo run --example crust_peer
     Running `target/debug/examples/crust_peer`
\
# Commands:
    prepare-connection-info <our-file>            - Use existing connections to find our external
    connect <our-file> <their-file>               - Initiate a connection to the remote endpoint
    send <connection-id> <message>                - Send a string to the given connection
    send-all <message>                            - Send a string to all connections
    list                                          - List existing connections and UDP sockets
    clean                                         - Remove disconnected connections from the list
    stop                                          - Exit the app
    help                                          - Print this help

# Where
    <our-file>      - The file where we'll read/write our connection info
    <their-file>    - The file where we'll read their connection info.
    <connection-id> - ID of a connection as listed using the `list` command

> 
Received event BootstrapFinished (not handled)
prepare-connection-info 2
> 
"2" with our connection info is ready
connect 2 1
Connecting to TheirConnectionInfo { secret: [54, 39, 194, 56], static_contact_info: StaticContactInfo { pub_key: PublicKey([231, 168, 29, 202, 10, 27, 145, 127, 40, 123, 112, 53, 114, 55, 17, 26, 57, 35, 255, 157, 18, 64, 99, 19, 91, 48, 254, 183, 45, 228, 49, 67]), tcp_acceptors: [SocketAddr(V4(127.0.0.1:36627)), SocketAddr(V4(10.0.0.100:36627)), SocketAddr(V4(192.168.100.1:36627)), SocketAddr(V6([::1]:36627)), SocketAddr(V4(127.0.0.1:36619)), SocketAddr(V4(10.0.0.100:36619)), SocketAddr(V4(192.168.100.1:36619)), SocketAddr(V6([::1]:36619))], udp_listeners: [SocketAddr(V4(127.0.0.1:60953)), SocketAddr(V4(10.0.0.100:60953)), SocketAddr(V4(192.168.100.1:60953)), SocketAddr(V6([::1]:60953))] }, udp_addrs: [SocketAddr(V4(127.0.0.1:46061)), SocketAddr(V4(10.0.0.100:46061)), SocketAddr(V4(192.168.100.1:46061)), SocketAddr(V6([::1]:46061))], pub_key: PublicKey([231, 168, 29, 202, 10, 27, 145, 127, 40, 123, 112, 53, 114, 55, 17, 26, 57, 35, 255, 157, 18, 64, 99, 19, 91, 48, 254, 183, 45, 228, 49, 67]) }
> 
Received event NewConnection { connection: Err(Error { repr: Custom(Custom { kind: TimedOut, error: StringError("Connection timed out") }) }), their_pub_key: PublicKey([231, 168, 29, 202, 10, 27, 145, 127, 40, 123, 112, 53, 114, 55, 17, 26, 57, 35, 255, 157, 18, 64, 99, 19, 91, 48, 254, 183, 45, 228, 49, 67]) } (not handled)
```

I have yet to investigate whether the error lies within `crust` or within `crust_peer`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/521)
<!-- Reviewable:end -->
