### PR TITLE
Use only TCP for now.

### DIFF
--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -508,7 +508,7 @@ fn main() {
                             continue;
                         },
                     };
-                    service.tcp_connect(our_info, their_info);
+                    service.connect(our_info, their_info);
                 }
                 UserCommand::Send(peer_index, message) => {
                     let network = unwrap_result!(network.lock());

--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -508,7 +508,7 @@ fn main() {
                             continue;
                         },
                     };
-                    service.connect(our_info, their_info);
+                    service.tcp_connect(our_info, their_info);
                 }
                 UserCommand::Send(peer_index, message) => {
                     let network = unwrap_result!(network.lock());

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -378,8 +378,10 @@ pub fn start_tcp_accept(port: u16,
                         continue;
                     }*/
                     let event = Event::NewPeer(Ok(()), peer_id);
-                    if event_tx.send(event).is_err() {
-                        break;
+                    if !cm.contains_key(&peer_id) {
+                        if event_tx.send(event).is_err() {
+                            break;
+                        }
                     }
                     peer_id
                 },

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -372,10 +372,11 @@ pub fn start_tcp_accept(port: u16,
                 },
                 Ok(CrustMsg::Connect(k)) => {
                     let peer_id = peer_id::new_id(k);
-                    if unwrap_result!(expected_peers.lock()).remove(&peer_id) {
+                    writer.send(WriteEvent::Write(CrustMsg::Connect(our_public_key)));
+                    /*if !unwrap_result!(expected_peers.lock()).remove(&peer_id) {
                         error!("Unexpected new peer: {:?}.", peer_id);
                         continue;
-                    }
+                    }*/
                     let event = Event::NewPeer(Ok(()), peer_id);
                     if event_tx.send(event).is_err() {
                         break;

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -378,7 +378,7 @@ pub fn start_tcp_accept(port: u16,
                         continue;
                     }*/
                     let event = Event::NewPeer(Ok(()), peer_id);
-                    if !cm.contains_key(&peer_id) {
+                    if cm.get(&peer_id).into_iter().all(Vec::is_empty) {
                         if event_tx.send(event).is_err() {
                             break;
                         }
@@ -418,7 +418,7 @@ pub fn start_tcp_accept(port: u16,
             };
 
             cm.entry(their_id)
-              .or_insert(Vec::new())
+              .or_insert_with(Vec::new)
               .push(connection);
         }
     }));

--- a/src/service.rs
+++ b/src/service.rs
@@ -442,6 +442,12 @@ impl Drop for Service {
     }
 }
 
+impl Drop for Service {
+    fn drop(&mut self) {
+        unwrap_result!(self.connection_map.lock()).clear();
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/service.rs
+++ b/src/service.rs
@@ -362,11 +362,12 @@ impl Service {
                                                        Some(their_id)) {
                     Err(e) => last_err = e,
                     Ok(connection) => {
-                        unwrap_result!(connection_map.lock())
-                            .entry(their_id)
-                            .or_insert(Vec::new())
-                            .push(connection);
-                        let _ = event_tx.send(Event::NewPeer(Ok(()), their_id));
+                        let mut guard = unwrap_result!(connection_map.lock());
+                        let connections = guard.entry(their_id).or_insert_with(Vec::new);
+                        if connections.is_empty() {
+                            let _ = event_tx.send(Event::NewPeer(Ok(()), their_id));
+                        }
+                        connections.push(connection);
                         return;
                     }
                 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -267,7 +267,7 @@ impl Service {
     /// Connecting]
     /// (https://github.com/maidsafe/crust/blob/master/docs/connect.md) for
     /// details on handling of connect in different protocols.
-    pub fn connect(&self,
+    pub fn _connect(&self,
                    our_connection_info: OurConnectionInfo,
                    their_connection_info: TheirConnectionInfo) {
         let event_tx = self.event_tx.clone();
@@ -338,7 +338,8 @@ impl Service {
     }
 
     /// Connect, but only via TCP.
-    pub fn tcp_connect(&self,
+    // TODO: Replace this with the current `_connect` once it works.
+    pub fn connect(&self,
                        our_connection_info: OurConnectionInfo,
                        their_connection_info: TheirConnectionInfo) {
         let their_id = their_connection_info.id;
@@ -441,12 +442,6 @@ impl Service {
     /// Returns our ID.
     pub fn id(&self) -> PeerId {
         peer_id::new_id(self.our_keys.0)
-    }
-}
-
-impl Drop for Service {
-    fn drop(&mut self) {
-        unwrap_result!(self.connection_map.lock()).clear();
     }
 }
 
@@ -718,8 +713,8 @@ mod test {
         let their_ci_0 = our_ci_0.to_their_connection_info();
         let their_ci_1 = our_ci_1.to_their_connection_info();
 
-        service_0.connect(our_ci_0, their_ci_1);
-        service_1.connect(our_ci_1, their_ci_0);
+        service_0._connect(our_ci_0, their_ci_1);
+        service_1._connect(our_ci_1, their_ci_0);
 
         let id_1 = match unwrap_result!(event_rx_0.recv()) {
             Event::NewPeer(Ok(()), their_id) => their_id,


### PR DESCRIPTION
This temporarily replaces `Service::connect` with a TCP-only version, since there are still unsolved UTP issues.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/541)
<!-- Reviewable:end -->
