### PR TITLE
Expose the PeerId in TheirConnectionInfo.

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -88,6 +88,13 @@ pub struct TheirConnectionInfo {
     id: PeerId,
 }
 
+impl TheirConnectionInfo {
+    /// Returns the `PeerId` of the node that created this connection info.
+    pub fn id(&self) -> PeerId {
+        self.id
+    }
+}
+
 /// A structure representing a connection manager.
 ///
 /// This abstraction has a hidden dependency on a config file. Refer to [the docs for `FileHandler`]


### PR DESCRIPTION
This will be needed if we decide to implement tunnel nodes, so that Routing can associate a `PeerId` with a `XorName`, even if the connection failed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/571)
<!-- Reviewable:end -->
