### PR TITLE
Improve peer list formatting in crust_peer

### DIFF
--- a/installer/sample.config
+++ b/installer/sample.config
@@ -1,27 +1,16 @@
 {
-  "hard_coded_contacts": [
-    {
-      "tcp_acceptors": [
-        "1.2.3.4:1234"
-      ],
-      "utp_custom_listeners": [
-        "2.3.4.5:2345"
-      ],
-      "udp_mapper_servers": [],
-      "tcp_mapper_servers": []
-    }
-  ],
+  "hard_coded_contacts": [],
   "tcp_acceptor_port": null,
   "utp_acceptor_port": null,
   "udp_mapper_servers": [
-    "162.243.228.81:39908",
-    "128.199.185.249:39223",
-    "178.62.82.189:52961"
+    "162.243.228.81:48730",
+    "178.62.82.189:35337",
+    "128.199.185.249:59680"
   ],
   "tcp_mapper_servers": [
-    "162.243.228.81:39908",
-    "128.199.185.249:39223",
-    "178.62.82.189:52961"
+    "162.243.228.81:38980",
+    "178.62.82.189:37677",
+    "128.199.185.249:45816"
   ],
   "enable_tcp": true,
   "enable_utp": true

--- a/installer/sample.config
+++ b/installer/sample.config
@@ -1,16 +1,27 @@
 {
-  "hard_coded_contacts": [],
+  "hard_coded_contacts": [
+    {
+      "tcp_acceptors": [
+        "1.2.3.4:1234"
+      ],
+      "utp_custom_listeners": [
+        "2.3.4.5:2345"
+      ],
+      "udp_mapper_servers": [],
+      "tcp_mapper_servers": []
+    }
+  ],
   "tcp_acceptor_port": null,
   "utp_acceptor_port": null,
   "udp_mapper_servers": [
-    "162.243.228.81:48730",
-    "178.62.82.189:35337",
-    "128.199.185.249:59680"
+    "162.243.228.81:39908",
+    "128.199.185.249:39223",
+    "178.62.82.189:52961"
   ],
   "tcp_mapper_servers": [
-    "162.243.228.81:38980",
-    "178.62.82.189:37677",
-    "128.199.185.249:45816"
+    "162.243.228.81:39908",
+    "128.199.185.249:39223",
+    "178.62.82.189:52961"
   ],
   "enable_tcp": true,
   "enable_utp": true

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -60,6 +60,14 @@ pub struct Connection {
     closed: Arc<AtomicBool>,
 }
 
+/// Information about a `Connection`
+pub struct ConnectionInfo {
+    pub protocol: Protocol,
+    pub our_addr: SocketAddr,
+    pub their_addr: SocketAddr,
+    pub closed: bool,
+}
+
 impl Hash for Connection {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.protocol.hash(state);
@@ -81,6 +89,16 @@ impl Debug for Connection {
 }
 
 impl Connection {
+    /// Get a `ConnectionInfo` that describes this connection.
+    pub fn get_info(&self) -> ConnectionInfo {
+        ConnectionInfo {
+            protocol: self.protocol,
+            our_addr: self.our_addr,
+            their_addr: self.their_addr,
+            closed: self.closed.load(Ordering::Relaxed),
+        }
+    }
+
     /// Send the `data` to a peer via this connection.
     pub fn send(&mut self, msg: CrustMsg) -> io::Result<()> {
         self.network_tx.send(msg)

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -19,6 +19,7 @@
 use util;
 use std::net;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::fmt;
 use rustc_serialize::{Encodable, Encoder, Decoder};
 use socket_addr::SocketAddr;
 
@@ -29,6 +30,15 @@ pub enum Protocol {
     Tcp,
     /// UTP protocol
     Utp,
+}
+
+impl fmt::Display for Protocol {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Protocol::Tcp => write!(f, "tcp"),
+            Protocol::Utp => write!(f, "utp"),
+        }
+    }
 }
 
 /// Enum representing endpoint of supported protocols

--- a/src/peer_id.rs
+++ b/src/peer_id.rs
@@ -17,7 +17,7 @@
 
 use rand;
 use rand::{Rand, Rng};
-use std::fmt::{Debug, Formatter, Result};
+use std::fmt::{Debug, Display, Formatter, Result};
 use sodiumoxide::crypto::box_;
 use sodiumoxide::crypto::box_::{PublicKey, PUBLICKEYBYTES};
 
@@ -29,6 +29,15 @@ impl Debug for PeerId {
     fn fmt(&self, formatter: &mut Formatter) -> Result {
         write!(formatter,
                "PeerId({:02x}{:02x}..)",
+               (self.0).0[0],
+               (self.0).0[1])
+    }
+}
+
+impl Display for PeerId {
+    fn fmt(&self, formatter: &mut Formatter) -> Result {
+        write!(formatter,
+               "{:02x}{:02x}..",
                (self.0).0[0],
                (self.0).0[1])
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -35,7 +35,7 @@ use udp_listener::RaiiUdpListener;
 use static_contact_info::StaticContactInfo;
 use rand;
 use config_handler::Config;
-use connection::Connection;
+use connection::{Connection, ConnectionInfo};
 use error::Error;
 use connection;
 use bootstrap;
@@ -272,6 +272,14 @@ impl Service {
             }
             Some(connection) => connection.send(CrustMsg::Message(data)),
         }
+    }
+
+    /// Get information about our connection to a peer.
+    pub fn connection_info(&self, id: &PeerId) -> Option<ConnectionInfo> {
+        unwrap_result!(self.connection_map.lock())
+                .get(&id)
+                .and_then(|conns| conns.get(0))
+                .and_then(|conn| Some(conn.get_info()))
     }
 
     /// Disconnect from the given peer and returns whether there was a connection at all.


### PR DESCRIPTION
This is a change that @viv asked for. The peer listing in `crust_peer` is a bit more readable and contains information on how we're connected to a peer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/585)
<!-- Reviewable:end -->
