### PR TITLE
Parallelise Service::connect function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ time = "~0.1.34"
 [dev-dependencies]
 docopt = "~0.6.78"
 void = "~1.0.1"
+loggerv = "~0.2.0"
 
 [[example]]
 bench = false

--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -46,6 +46,7 @@ extern crate docopt;
 extern crate rand;
 extern crate term;
 extern crate time;
+extern crate loggerv;
 
 use docopt::Docopt;
 use rand::random;
@@ -309,7 +310,7 @@ fn handle_new_peer(service: &Service, protected_network: Arc<Mutex<Network>>, pe
 }
 
 fn main() {
-    ::maidsafe_utilities::log::init(true);
+    unwrap_result!(loggerv::init_with_level(log::LogLevel::Warn));
 
     let args: Args = Docopt::new(USAGE)
                          .and_then(|docopt| docopt.decode())

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -172,7 +172,7 @@ pub fn connect(peer_contact: StaticContactInfo,
 
     if utp_enabled {
         let (udp_socket, (our_priv_info, our_pub_info)) = {
-            match MappedUdpSocket::new(mc).result_discard() {
+            match MappedUdpSocket::new(mc).result_log() {
                 Ok(MappedUdpSocket { socket, endpoints }) => {
                     (socket, gen_rendezvous_info(endpoints))
                 }
@@ -203,7 +203,7 @@ pub fn connect(peer_contact: StaticContactInfo,
                             let cloned_udp_socket = try!(udp_socket.try_clone());
                             match PunchedUdpSocket::punch_hole(cloned_udp_socket,
                                                                our_priv_info.clone(),
-                                                               their_info).result_discard() {
+                                                               their_info).result_log() {
                                 Ok(PunchedUdpSocket { socket, peer_addr }) => {
                                     match utp_rendezvous_connect(
                                         socket,

--- a/src/service.rs
+++ b/src/service.rs
@@ -18,7 +18,8 @@
 use std::collections::{HashMap, HashSet};
 use std::io;
 use std::net;
-use std::sync::{Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex};
+use std::fmt::Write;
 use service_discovery::ServiceDiscovery;
 use sodiumoxide;
 use sodiumoxide::crypto::box_;
@@ -355,100 +356,140 @@ impl Service {
 
         unwrap_result!(self.expected_peers.lock()).insert(their_connection_info.id);
 
-        // TODO connect to all the socket addresses of peer in parallel
-        let _joiner = thread!("PeerConnectionThread", move || {
-            let mut last_err = io::Error::new(io::ErrorKind::NotFound,
-                                              "No TCP acceptors found.");
-            if tcp_enabled {
-                let static_contact_info = their_connection_info.static_contact_info.clone();
-                for tcp_addr in their_connection_info.static_contact_info.tcp_acceptors {
+        let (result_tx, result_rx) = mpsc::channel();
+
+        if tcp_enabled {
+            let static_contact_info = their_connection_info.static_contact_info.clone();
+            for tcp_addr in their_connection_info.static_contact_info.tcp_acceptors {
+                let our_contact_info = our_contact_info.clone();
+                let event_tx = event_tx.clone();
+                let connection_map = connection_map.clone();
+                let result_tx = result_tx.clone();
+                let bootstrap_cache = bootstrap_cache.clone();
+                let static_contact_info = static_contact_info.clone();
+                let _ = thread!("Service::connect tcp direct", move || {
                     match connection::connect_tcp_endpoint(tcp_addr,
-                                                           our_contact_info.clone(),
+                                                           our_contact_info,
                                                            our_public_key,
-                                                           event_tx.clone(),
-                                                           connection_map.clone(),
+                                                           event_tx,
+                                                           connection_map,
                                                            Some(their_id)) {
                         Err(err) => {
-                            last_err = err;
-                            continue;
-                        }
+                            let err_msg = format!("Tcp direct connect failed: {}", err);
+                            let err = io::Error::new(err.kind(), err_msg);
+                            result_tx.send(Err(err));
+                        },
                         Ok(()) => {
+                            result_tx.send(Ok(()));
                             unwrap_result!(bootstrap_cache.lock()).update_contacts(
                                 vec![static_contact_info],
                                 vec![]
                             );
-                            return;
-                        }
+                        },
                     }
-                };
-
-            }
-
-            if let Some(udp_socket) = our_connection_info.udp_socket {
-                let res = PunchedUdpSocket::punch_hole(udp_socket,
-                                                       our_connection_info.priv_udp_info,
-                                                       their_connection_info.udp_info).result_log();
-                let (udp_socket, public_endpoint) = match res {
-                    Ok(PunchedUdpSocket { socket, peer_addr }) => (socket, peer_addr),
-                    Err(_) => {
-                        let mut cm = unwrap_result!(connection_map.lock());
-                        if !cm.contains_key(&their_id) {
-                            let ev = Event::NewPeer(Err(io::Error::new(io::ErrorKind::Other,
-                                                                       "Failed to punch a hole")),
-                                                    their_id);
-                            let _ = event_tx.send(ev);
-                        }
-                        return;
-                    }
-                };
-
-                match connection::utp_rendezvous_connect(udp_socket,
-                                                         public_endpoint,
-                                                         UtpRendezvousConnectMode::Normal(their_id),
-                                                         our_public_key.clone(),
-                                                         event_tx.clone(),
-                                                         connection_map.clone()) {
-                    Err(e) => {
-                        let mut cm = unwrap_result!(connection_map.lock());
-                        if !cm.contains_key(&their_id) {
-                            let _ = event_tx.send(Event::NewPeer(Err(e), their_id));
-                        }
-                    }
-                    Ok(connection) => return,
-                };
+                });
             }
 
             if let Some(tcp_socket) = our_connection_info.tcp_socket {
-                let res = tcp_punch_hole(tcp_socket,
-                                         our_connection_info.priv_tcp_info,
-                                         their_connection_info.tcp_info).result_log();
-                match res {
-                    Ok(tcp_stream) => {
-                        match connection::tcp_rendezvous_connect(connection_map.clone(),
-                                                                 event_tx.clone(),
-                                                                 tcp_stream,
-                                                                 their_connection_info.id) {
-                            Ok(()) => {
-                                let mut c_map = unwrap_result!(connection_map.lock());
-                                let connections = c_map.entry(their_id).or_insert_with(|| Vec::with_capacity(1));
-                                if connections.is_empty() {
-                                    let _ = event_tx.send(Event::NewPeer(Ok(()), their_id));
-                                }
-                                return;
-                            },
-                            Err(e) => {
-                                last_err = From::from(e);
-                            },
-                        };
-                    },
-                    Err(e) => {
-                        last_err = From::from(e);
-                    },
-                };
-            }
+                let tcp_info = their_connection_info.tcp_info;
+                let event_tx = event_tx.clone();
+                let connection_map = connection_map.clone();
+                let result_tx = result_tx.clone();
+                let priv_tcp_info = our_connection_info.priv_tcp_info;
+                let _ = thread!("Service::connect tcp rendezvous", move || {
+                    let res = tcp_punch_hole(tcp_socket,
+                                             priv_tcp_info,
+                                             tcp_info).result_log();
+                    match res {
+                        Ok(tcp_stream) => {
+                            match connection::tcp_rendezvous_connect(connection_map,
+                                                                     event_tx,
+                                                                     tcp_stream,
+                                                                     their_id) {
+                                Ok(()) => {
+                                    result_tx.send(Ok(()));
+                                },
+                                Err(err) => {
+                                    let err_msg = format!("Tcp rendezvous connect failed: {}", err);
+                                    let err = io::Error::new(err.kind(), err_msg);
+                                    result_tx.send(Err(err));
+                                },
+                            }
+                        },
+                        Err(err) => {
+                            let err: io::Error = From::from(err);
+                            let err_msg = format!("Tcp hole punching failed: {}", err);
+                            let err = io::Error::new(err.kind(), err_msg);
+                            result_tx.send(Err(err));
+                        },
+                    };
+                });
+            };
+        }
 
-            if unwrap_result!(connection_map.lock()).get(&their_id).into_iter().all(Vec::is_empty) {
-                let _ = event_tx.send(Event::NewPeer(Err(last_err), their_id));
+        if utp_enabled {
+            if let Some(udp_socket) = our_connection_info.udp_socket {
+                let priv_udp_info = our_connection_info.priv_udp_info;
+                let udp_info = their_connection_info.udp_info;
+                let event_tx = event_tx.clone();
+                let connection_map = connection_map.clone();
+                let result_tx = result_tx.clone();
+                let _ = thread!("Service::connect utp rendezvous", move || {
+                    let res = PunchedUdpSocket::punch_hole(udp_socket,
+                                                           priv_udp_info,
+                                                           udp_info).result_log();
+                    let (udp_socket, public_endpoint) = match res {
+                        Ok(PunchedUdpSocket { socket, peer_addr}) => (socket, peer_addr),
+                        Err(err) => {
+                            let err: io::Error = From::from(err);
+                            let err_msg = format!("Udp hole punching failed: {}", err);
+                            let err = io::Error::new(err.kind(), err_msg);
+                            result_tx.send(Err(err));
+                            return;
+                        },
+                    };
+                    match connection::utp_rendezvous_connect(udp_socket,
+                                                             public_endpoint,
+                                                             UtpRendezvousConnectMode::Normal(their_id),
+                                                             our_public_key.clone(),
+                                                             event_tx,
+                                                             connection_map) {
+                        Err(err) => {
+                            let err_msg = format!("Utp rendezvous connect failed: {}", err);
+                            let err = io::Error::new(err.kind(), err_msg);
+                            result_tx.send(Err(err));
+                        },
+                        Ok(_) => {
+                            result_tx.send(Ok(()));
+                        },
+                    };
+                });
+            };
+        }
+
+        let _ = thread!("Service::connect aggregate results", move || {
+            let mut errors: Vec<io::Error> = Vec::new();
+            loop {
+                match result_rx.recv() {
+                    // Don't need to send a message here. Stupidly, the connect functions will have
+                    // raised the event from deep within them.
+                    Ok(Ok(())) => break,
+                    Ok(Err(err)) => {
+                        errors.push(err);
+                    },
+                    Err(mpsc::RecvError) => {
+                        // All of the senders have hung up without sending us an Ok(()). They all
+                        // must have failed to connect.
+                        let len = errors.len();
+                        let mut err_str: String = From::from("Connect failed. errors:");
+                        for (i, e) in errors.into_iter().enumerate() {
+                            write!(err_str, " ({} of {}) {}", i + 1, len, e);
+                        }
+                        let err = io::Error::new(io::ErrorKind::TimedOut, err_str);
+                        let _ = event_tx.send(Event::NewPeer(Err(err), their_id));
+                        return;
+                    },
+                }
             }
         });
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -163,7 +163,7 @@ impl Service {
         let service_discovery = try!(ServiceDiscovery::new_with_generator(service_discovery_port,
                                                                           generator));
 
-        let mapping_context = try!(MappingContext::new().result_discard()
+        let mapping_context = try!(MappingContext::new().result_log()
                                    .or_else(|e| {
             Err(io::Error::new(io::ErrorKind::Other,
                                format!("Failed to create MappingContext: {}", e)))
@@ -196,11 +196,11 @@ impl Service {
                                            config.enable_utp);
 
         let udp_hole_punch_server
-            = try!(SimpleUdpHolePunchServer::new(mapping_context.clone()).result_discard()
+            = try!(SimpleUdpHolePunchServer::new(mapping_context.clone()).result_log()
                    .or(Err(io::Error::new(io::ErrorKind::Other,
                                           "Failed to create UDP hole punch server"))));
         let tcp_hole_punch_server
-            = try!(SimpleTcpHolePunchServer::new(mapping_context.clone()).result_discard()
+            = try!(SimpleTcpHolePunchServer::new(mapping_context.clone()).result_log()
                    .or(Err(io::Error::new(io::ErrorKind::Other,
                                           "Failed to create TCP hole punch server"))));
 
@@ -387,7 +387,7 @@ impl Service {
             if let Some(udp_socket) = our_connection_info.udp_socket {
                 let res = PunchedUdpSocket::punch_hole(udp_socket,
                                                        our_connection_info.priv_udp_info,
-                                                       their_connection_info.udp_info).result_discard();
+                                                       their_connection_info.udp_info).result_log();
                 let (udp_socket, public_endpoint) = match res {
                     Ok(PunchedUdpSocket { socket, peer_addr }) => (socket, peer_addr),
                     Err(_) => {
@@ -463,7 +463,7 @@ impl Service {
         let event_tx = self.event_tx.clone();
 
         let result_external_socket = MappedUdpSocket::new(&self.mapping_context)
-            .result_discard();
+            .result_log();
         let mapping_context = self.mapping_context.clone();
         let our_pub_key = self.our_keys.0.clone();
         let tcp_enabled = self.tcp_enabled;

--- a/src/udp_listener.rs
+++ b/src/udp_listener.rs
@@ -70,7 +70,7 @@ impl RaiiUdpListener {
         // Local addresses as they will be used by processes in LAN where TCP is disallowed.
         let mut addrs = Vec::new();
         if let Ok(MappedUdpSocket { endpoints, socket })
-            = MappedUdpSocket::map(try!(udp_socket.try_clone()), &mc).result_discard() {
+            = MappedUdpSocket::map(try!(udp_socket.try_clone()), &mc).result_log() {
             addrs.extend(endpoints.into_iter().map(|ma| ma.addr));
             let local_addr = unwrap_result!(socket.local_addr());
             addrs.push(SocketAddr(local_addr));
@@ -131,7 +131,7 @@ impl RaiiUdpListener {
             ListenerRequest::Connect { our_info, .. } => {
                 let their_info = our_info;
                 let MappedUdpSocket { socket, endpoints } = {
-                    match MappedUdpSocket::new(&mc).result_discard() {
+                    match MappedUdpSocket::new(&mc).result_log() {
                         Ok(mapped_socket) => mapped_socket,
                         Err(_) => return,
                     }
@@ -151,7 +151,7 @@ impl RaiiUdpListener {
                 }
 
                 let PunchedUdpSocket { socket, peer_addr } = {
-                    match PunchedUdpSocket::punch_hole(socket, our_priv_info, their_info).result_discard() {
+                    match PunchedUdpSocket::punch_hole(socket, our_priv_info, their_info).result_log() {
                         Ok(punched_socket) => punched_socket,
                         Err(e) => return,
                     }


### PR DESCRIPTION
Make the `Service::connect` function try all it's connection methods in parallel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/591)
<!-- Reviewable:end -->
