### PR TITLE
Improve logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ time = "~0.1.34"
 [dev-dependencies]
 docopt = "~0.6.78"
 void = "~1.0.1"
+loggerv = "~0.2.0"
 
 [[example]]
 bench = false

--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -46,6 +46,7 @@ extern crate docopt;
 extern crate rand;
 extern crate term;
 extern crate time;
+extern crate loggerv;
 
 use docopt::Docopt;
 use rand::random;
@@ -309,7 +310,7 @@ fn handle_new_peer(service: &Service, protected_network: Arc<Mutex<Network>>, pe
 }
 
 fn main() {
-    ::maidsafe_utilities::log::init(true);
+    unwrap_result!(loggerv::init_with_level(log::LogLevel::Warn));
 
     let args: Args = Docopt::new(USAGE)
                          .and_then(|docopt| docopt.decode())

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -172,7 +172,7 @@ pub fn connect(peer_contact: StaticContactInfo,
 
     if utp_enabled {
         let (udp_socket, (our_priv_info, our_pub_info)) = {
-            match MappedUdpSocket::new(mc).result_discard() {
+            match MappedUdpSocket::new(mc).result_log() {
                 Ok(MappedUdpSocket { socket, endpoints }) => {
                     (socket, gen_rendezvous_info(endpoints))
                 }
@@ -203,7 +203,7 @@ pub fn connect(peer_contact: StaticContactInfo,
                             let cloned_udp_socket = try!(udp_socket.try_clone());
                             match PunchedUdpSocket::punch_hole(cloned_udp_socket,
                                                                our_priv_info.clone(),
-                                                               their_info).result_discard() {
+                                                               their_info).result_log() {
                                 Ok(PunchedUdpSocket { socket, peer_addr }) => {
                                     match utp_rendezvous_connect(
                                         socket,

--- a/src/service.rs
+++ b/src/service.rs
@@ -163,7 +163,7 @@ impl Service {
         let service_discovery = try!(ServiceDiscovery::new_with_generator(service_discovery_port,
                                                                           generator));
 
-        let mapping_context = try!(MappingContext::new().result_discard()
+        let mapping_context = try!(MappingContext::new().result_log()
                                    .or_else(|e| {
             Err(io::Error::new(io::ErrorKind::Other,
                                format!("Failed to create MappingContext: {}", e)))
@@ -196,11 +196,11 @@ impl Service {
                                            config.enable_utp);
 
         let udp_hole_punch_server
-            = try!(SimpleUdpHolePunchServer::new(mapping_context.clone()).result_discard()
+            = try!(SimpleUdpHolePunchServer::new(mapping_context.clone()).result_log()
                    .or(Err(io::Error::new(io::ErrorKind::Other,
                                           "Failed to create UDP hole punch server"))));
         let tcp_hole_punch_server
-            = try!(SimpleTcpHolePunchServer::new(mapping_context.clone()).result_discard()
+            = try!(SimpleTcpHolePunchServer::new(mapping_context.clone()).result_log()
                    .or(Err(io::Error::new(io::ErrorKind::Other,
                                           "Failed to create TCP hole punch server"))));
 
@@ -387,7 +387,7 @@ impl Service {
             if let Some(udp_socket) = our_connection_info.udp_socket {
                 let res = PunchedUdpSocket::punch_hole(udp_socket,
                                                        our_connection_info.priv_udp_info,
-                                                       their_connection_info.udp_info).result_discard();
+                                                       their_connection_info.udp_info).result_log();
                 let (udp_socket, public_endpoint) = match res {
                     Ok(PunchedUdpSocket { socket, peer_addr }) => (socket, peer_addr),
                     Err(_) => {
@@ -463,7 +463,7 @@ impl Service {
         let event_tx = self.event_tx.clone();
 
         let result_external_socket = MappedUdpSocket::new(&self.mapping_context)
-            .result_discard();
+            .result_log();
         let mapping_context = self.mapping_context.clone();
         let our_pub_key = self.our_keys.0.clone();
         let tcp_enabled = self.tcp_enabled;

--- a/src/udp_listener.rs
+++ b/src/udp_listener.rs
@@ -70,7 +70,7 @@ impl RaiiUdpListener {
         // Local addresses as they will be used by processes in LAN where TCP is disallowed.
         let mut addrs = Vec::new();
         if let Ok(MappedUdpSocket { endpoints, socket })
-            = MappedUdpSocket::map(try!(udp_socket.try_clone()), &mc).result_discard() {
+            = MappedUdpSocket::map(try!(udp_socket.try_clone()), &mc).result_log() {
             addrs.extend(endpoints.into_iter().map(|ma| ma.addr));
             let local_addr = unwrap_result!(socket.local_addr());
             addrs.push(SocketAddr(local_addr));
@@ -131,7 +131,7 @@ impl RaiiUdpListener {
             ListenerRequest::Connect { our_info, .. } => {
                 let their_info = our_info;
                 let MappedUdpSocket { socket, endpoints } = {
-                    match MappedUdpSocket::new(&mc).result_discard() {
+                    match MappedUdpSocket::new(&mc).result_log() {
                         Ok(mapped_socket) => mapped_socket,
                         Err(_) => return,
                     }
@@ -151,7 +151,7 @@ impl RaiiUdpListener {
                 }
 
                 let PunchedUdpSocket { socket, peer_addr } = {
-                    match PunchedUdpSocket::punch_hole(socket, our_priv_info, their_info).result_discard() {
+                    match PunchedUdpSocket::punch_hole(socket, our_priv_info, their_info).result_log() {
                         Ok(punched_socket) => punched_socket,
                         Err(e) => return,
                     }


### PR DESCRIPTION
Make the crust_peer example print logging information to the terminal rather than going through the maidsafe_utilities logging framework. Replace every occurrence of `WResult::result_discard` with `WResult::result_log` so that we can see the warnings that are raised.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/592)
<!-- Reviewable:end -->
