### PR TITLE
Thread-Local bootstrap cache filename

### DIFF
--- a/src/bootstrap_handler.rs
+++ b/src/bootstrap_handler.rs
@@ -99,6 +99,17 @@ impl BootstrapHandler {
     }
 }
 
+#[cfg(test)]
+#[allow(unsafe_code)]
+pub fn get_default_file_name() -> Result<OsString, Error> {
+    use libc;
+    let mut name = try!(config_file_handler::exe_file_stem());
+    let thread_id = unsafe { libc::pthread_self() };
+    name.push(format!(".bootstrap.cache._{}", thread_id));
+    Ok(name)
+}
+
+#[cfg(not(test))]
 pub fn get_default_file_name() -> Result<OsString, Error> {
     let mut name = try!(config_file_handler::exe_file_stem());
     name.push(".bootstrap.cache");
@@ -107,6 +118,28 @@ pub fn get_default_file_name() -> Result<OsString, Error> {
 
 #[cfg(test)]
 mod test {
+
+    use std::thread;
+
+    #[test]
+    fn thread_local_cache_for_test() {
+    // Running get_file_name from different threads
+    // during tests, should return thread-local-filenames.
+    // This allows us to run tests in parallel without
+    // race conditions on the bootstrap cache.
+    // See https://github.com/maidsafe/crust/issues/600
+
+        let child_a = thread::spawn(move || {
+            ::bootstrap_handler::get_default_file_name()
+        });
+
+        let child_b = thread::spawn(move || {
+            ::bootstrap_handler::get_default_file_name()
+        });
+
+        assert!(child_a.join().unwrap().unwrap() !=  child_b.join().unwrap().unwrap())
+
+    }
 
     // TODO(canndrew): Add these tests back
     // the main thing that has changed is that StaticContactInfo has replaced Endpoint. Probably nothing


### PR DESCRIPTION
Replaces bootstrap_handlers' get_file_name in test with a thread-local
version. This local one returns a filename for the current thread only
ensuring we can't run into race bootstrap-file-caused race conditions.

Comes with test that ensure we are getting different file names during
testing. (Not sure why the other tests in there are commented out
though.)

Fixes maidsafe/crust#600

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/611)
<!-- Reviewable:end -->