### PR TITLE
Remove time crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ socket_addr = "~0.1.0"
 sodiumoxide = "~0.0.10"
 temp_utp = "~0.8.1"
 term = "~0.4.4"
-time = "~0.1.35"
 
 [dev-dependencies]
 docopt = "~0.6.80"

--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -45,7 +45,6 @@ extern crate rustc_serialize;
 extern crate docopt;
 extern crate rand;
 extern crate term;
-extern crate time;
 
 use docopt::Docopt;
 use rand::random;
@@ -59,7 +58,7 @@ use std::net;
 use std::str::FromStr;
 use std::thread;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Instant, Duration};
 use std::collections::{BTreeMap, HashMap};
 
 use crust::{Service, Protocol, Endpoint, ConnectionInfoResult,
@@ -138,8 +137,8 @@ fn generate_random_vec_u8(size: usize) -> Vec<u8> {
 struct Network {
     nodes: HashMap<usize, PeerId>,
     our_connection_infos: BTreeMap<u32, OurConnectionInfo>,
-    performance_start: time::SteadyTime,
-    performance_interval: time::Duration,
+    performance_start: Instant,
+    performance_interval: Duration,
     received_msgs: u32,
     received_bytes: usize,
     peer_index: usize,
@@ -152,8 +151,8 @@ impl Network {
         Network {
             nodes: HashMap::new(),
             our_connection_infos: BTreeMap::new(),
-            performance_start: time::SteadyTime::now(),
-            performance_interval: time::Duration::seconds(10),
+            performance_start: Instant::now(),
+            performance_interval: Duration::from_secs(10),
             received_msgs: 0,
             received_bytes: 0,
             peer_index: 0,
@@ -219,13 +218,13 @@ impl Network {
         self.received_msgs += 1;
         self.received_bytes += msg_size;
         if self.received_msgs == 1 {
-            self.performance_start = time::SteadyTime::now();
+            self.performance_start = Instant::now();
         }
-        if self.performance_start + self.performance_interval < time::SteadyTime::now() {
+        if self.performance_start + self.performance_interval < Instant::now() {
             println!("\nReceived {} messages with total size of {} bytes in last {} seconds.",
                      self.received_msgs,
                      self.received_bytes,
-                     self.performance_interval.num_seconds());
+                     self.performance_interval.as_secs());
             self.received_msgs = 0;
             self.received_bytes = 0;
         }

--- a/src/bootstrap_handler.rs
+++ b/src/bootstrap_handler.rs
@@ -16,6 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 use std::ffi::OsString;
+use std::time::{Instant, Duration};
 
 use error::Error;
 use static_contact_info::StaticContactInfo;
@@ -26,7 +27,7 @@ const ENABLE_BOOTSTRAP_CACHE: bool = false;
 
 pub struct BootstrapHandler {
     file_handler: FileHandler<Vec<StaticContactInfo>>,
-    last_updated: ::time::Tm,
+    last_updated: Instant,
 }
 
 impl BootstrapHandler {
@@ -45,7 +46,7 @@ impl BootstrapHandler {
 
         Ok(BootstrapHandler {
             file_handler: try!(FileHandler::new(&name)),
-            last_updated: ::time::now(),
+            last_updated: Instant::now(),
         })
     }
 
@@ -56,7 +57,7 @@ impl BootstrapHandler {
         if ENABLE_BOOTSTRAP_CACHE {
             try!(self.insert_contacts(contacts, prune));
             // TODO(Team) this implementation is missing and should be considered in next planning
-            if ::time::now() > self.last_updated + Self::duration_between_updates() {
+            if Instant::now() > self.last_updated + Self::duration_between_updates() {
                 // self.check_bootstrap_contacts();
             }
         }
@@ -67,8 +68,8 @@ impl BootstrapHandler {
         Ok(try!(self.file_handler.read_file()))
     }
 
-    fn duration_between_updates() -> ::time::Duration {
-        ::time::Duration::hours(4)
+    fn duration_between_updates() -> Duration {
+        Duration::from_secs(4 * 60 * 60)
     }
 
     fn max_contacts() -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@ extern crate log;
 extern crate net2;
 extern crate rand;
 extern crate rustc_serialize;
-extern crate time;
 extern crate utp;
 #[macro_use]
 extern crate maidsafe_utilities;

--- a/src/socket_utils.rs
+++ b/src/socket_utils.rs
@@ -17,40 +17,48 @@
 
 use std::io;
 use std::net::UdpSocket;
-use socket_addr::SocketAddr;
 use std::io::ErrorKind;
+use std::time::Instant;
+
+use socket_addr::SocketAddr;
 
 /// A self interruptable receive trait that allows a timed-out period to be defined
 pub trait RecvUntil {
     /// After specified timed-out period, the blocking receive method shall return with an error
     fn recv_until(&self,
                   buf: &mut [u8],
-                  deadline: ::time::SteadyTime)
+                  deadline: Instant)
                   -> io::Result<Option<(usize, SocketAddr)>>;
 }
 
 impl RecvUntil for UdpSocket {
     fn recv_until(&self,
                   buf: &mut [u8],
-                  deadline: ::time::SteadyTime)
+                  deadline: Instant)
                   -> io::Result<Option<(usize, SocketAddr)>> {
+        let old_timeout = try!(self.read_timeout());
         loop {
-            let current_time = ::time::SteadyTime::now();
-            let timeout_ms = (deadline - current_time).num_milliseconds();
-
-            if timeout_ms <= 0 {
+            let current_time = Instant::now();
+            if current_time >= deadline {
+                try!(self.set_read_timeout(old_timeout));
                 return Ok(None);
             }
-
-            // TODO (canndrew): should eventually be able to remove this conversion
-            let timeout = ::std::time::Duration::from_millis(timeout_ms as u64);
-            try!(self.set_read_timeout(Some(timeout)));
+            {
+                let timeout = deadline - current_time;
+                try!(self.set_read_timeout(Some(timeout)));
+            }
 
             match self.recv_from(buf) {
-                Ok((bytes_len, addr)) => return Ok(Some((bytes_len, SocketAddr(addr)))),
+                Ok((bytes_len, addr)) => {
+                    try!(self.set_read_timeout(old_timeout));
+                    return Ok(Some((bytes_len, SocketAddr(addr))));
+                },
                 Err(e) => {
                     match e.kind() {
-                        ErrorKind::TimedOut | ErrorKind::WouldBlock => return Ok(None),
+                        ErrorKind::TimedOut | ErrorKind::WouldBlock => {
+                            try!(self.set_read_timeout(old_timeout));
+                            return Ok(None);
+                        },
                         ErrorKind::Interrupted => (),
                         // On Windows, when we send a packet to an endpoint
                         // which is not being listened on, the system responds
@@ -60,7 +68,10 @@ impl RecvUntil for UdpSocket {
                         // See here for more info:
                         // https://bobobobo.wordpress.com/2009/05/17/udp-an-existing-connection-was-forcibly-closed-by-the-remote-host/
                         ErrorKind::ConnectionReset => (),
-                        _ => return Err(e),
+                        _ => {
+                            try!(self.set_read_timeout(old_timeout));
+                            return Err(e);
+                        },
                     }
                 }
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,16 +19,6 @@ use std::cmp::Ordering;
 use get_if_addrs::{get_if_addrs, Interface, IfAddr};
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use ip_info;
-use time;
-use std;
-
-pub fn time_duration_to_std_duration(dur: time::Duration) -> std::time::Duration {
-    let secs = dur.num_seconds();
-    let nanos = (dur - time::Duration::seconds(secs)).num_nanoseconds().unwrap();
-    let secs =  if secs < 0 { 0 } else { secs as u64 };
-    let nanos = if nanos < 0 { 0 } else { nanos as u32 };
-    std::time::Duration::new(secs, nanos)
-}
 
 /// /////////////////////////////////////////////////////////////////////////////
 pub fn is_unspecified(ip_addr: &IpAddr) -> bool {


### PR DESCRIPTION
Remove usage of the `time` crate now that `std::time::Instant` and friends are stable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/648)
<!-- Reviewable:end -->