### PR TITLE
fix/tcp: heartbeat not being sent on some cases

### DIFF
--- a/src/tcp_connections.rs
+++ b/src/tcp_connections.rs
@@ -88,12 +88,7 @@ fn upgrade_writer(mut stream: TcpStream,
                                                info!("Stale connection. Dropping...");
                                                break;
                                            }
-                                           let last_activity = if last_write_activity > last_read_activity {
-                                               last_write_activity
-                                           } else {
-                                               last_read_activity
-                                           };
-                                           let heartbeat_deadline = last_activity + heartbeat_timeout;
+                                           let heartbeat_deadline = last_write_activity + heartbeat_timeout;
                                            if now > heartbeat_deadline {
                                                if let Err(e) = stream.write_all(&heartbeat_msg) {
                                                    error!("Error sending: {:?}", e);


### PR DESCRIPTION
There was a scenario where hearbeat implementation would fail:

> if peer A is sending data to peer B and never receives a heartbeat
> it'll eventually conclude that peer B has disconnected (even if it was
> still getting acks at the tcp level).

To fix the problem, we should only take `last_write_activity` into
consideration to compute the heartbeat timeout.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/654)

<!-- Reviewable:end -->
