### PR TITLE
EXPERIMENT - DO NOT MERGE: Try dropping large, delayed messages.

### DIFF
--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -20,7 +20,7 @@ use util;
 use std::net;
 use std::net::IpAddr;
 use std::fmt;
-use rustc_serialize::{Encodable, Encoder, Decoder};
+use rustc_serialize::{Encoder, Decoder};
 use socket_addr::SocketAddr;
 
 /// Enum representing supported transport protocols

--- a/src/event.rs
+++ b/src/event.rs
@@ -18,6 +18,7 @@
 use peer_id::PeerId;
 use service::ConnectionInfoResult;
 use std::io;
+use std::time::Instant;
 use sender_receiver::CrustMsg;
 
 // This is necessary to gracefully exit the threads. In current design, there is no control over
@@ -26,7 +27,7 @@ use sender_receiver::CrustMsg;
 // the future.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum WriteEvent {
-    Write(CrustMsg),
+    Write(CrustMsg, Instant),
     Shutdown,
 }
 

--- a/src/sender_receiver.rs
+++ b/src/sender_receiver.rs
@@ -21,6 +21,7 @@ use std::io;
 use std::sync::mpsc;
 use std::io::BufReader;
 use std::net::TcpStream;
+use std::time::Instant;
 use rustc_serialize::Decodable;
 use utp_connections::UtpWrapper;
 use maidsafe_utilities::serialisation::deserialise_from;
@@ -32,7 +33,7 @@ pub struct RaiiSender(pub mpsc::Sender<WriteEvent>);
 impl RaiiSender {
     pub fn send(&self, msg: CrustMsg) -> io::Result<()> {
         self.0
-            .send(WriteEvent::Write(msg))
+            .send(WriteEvent::Write(msg, Instant::now()))
             .map_err(|_| io::Error::new(io::ErrorKind::NotConnected, "can't send"))
     }
 }

--- a/src/static_contact_info.rs
+++ b/src/static_contact_info.rs
@@ -16,7 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 use socket_addr::SocketAddr;
-use rustc_serialize::{Encodable, Encoder, Decoder};
+use rustc_serialize::{Encoder, Decoder};
 
 /// This struct contains information needed to Bootstrap and for echo-server services
 #[derive(RustcEncodable, RustcDecodable, Debug, Default, Clone, PartialEq, Eq, Hash)]

--- a/src/utp_connections.rs
+++ b/src/utp_connections.rs
@@ -27,23 +27,28 @@ use socket_addr::SocketAddr;
 pub use utp_wrapper::UtpWrapper;
 use event::WriteEvent;
 
-pub fn rendezvous_connect_utp(udp_socket: UdpSocket, addr: SocketAddr,
+pub fn rendezvous_connect_utp(udp_socket: UdpSocket,
+                              addr: SocketAddr,
                               heartbeat_timeout: Duration,
                               inactivity_timeout: Duration)
                               -> io::Result<(UtpWrapper, Sender<WriteEvent>)> {
     upgrade_utp(try!(UtpSocket::rendezvous_connect(udp_socket, &*addr)),
-                heartbeat_timeout, inactivity_timeout)
+                heartbeat_timeout,
+                inactivity_timeout)
 }
 
 /// Upgrades a newly connected UtpSocket to a Sender-Receiver pair that you can use to send and
 /// receive objects automatically.  If there is an error decoding or encoding
 /// values, that respective part is shut down.
-pub fn upgrade_utp(newconnection: UtpSocket, heartbeat_timeout: Duration,
+pub fn upgrade_utp(newconnection: UtpSocket,
+                   heartbeat_timeout: Duration,
                    inactivity_timeout: Duration)
                    -> io::Result<(UtpWrapper, Sender<WriteEvent>)> {
     let (output_tx, output_rx) = mpsc::channel();
-    let wrapper = try!(UtpWrapper::wrap(newconnection, output_rx,
-                                        heartbeat_timeout, inactivity_timeout));
+    let wrapper = try!(UtpWrapper::wrap(newconnection,
+                                        output_rx,
+                                        heartbeat_timeout,
+                                        inactivity_timeout));
 
     Ok((wrapper, output_tx))
 }
@@ -80,8 +85,16 @@ mod test {
         let port_0 = unwrap_result!(socket_0.local_addr()).port();
         let port_1 = unwrap_result!(socket_1.local_addr()).port();
 
-        let addr_0 = SocketAddr(net::SocketAddr::V4(net::SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), port_0)));
-        let addr_1 = SocketAddr(net::SocketAddr::V4(net::SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), port_1)));
+        let addr_0 = SocketAddr(net::SocketAddr::V4(net::SocketAddrV4::new(Ipv4Addr::new(127,
+                                                                                         0,
+                                                                                         0,
+                                                                                         1),
+                                                                           port_0)));
+        let addr_1 = SocketAddr(net::SocketAddr::V4(net::SocketAddrV4::new(Ipv4Addr::new(127,
+                                                                                         0,
+                                                                                         0,
+                                                                                         1),
+                                                                           port_1)));
 
         let th0 = spawn(move || {
             let (mut i, o) = unwrap_result!(rendezvous_connect_utp(socket_0, addr_1,
@@ -94,17 +107,19 @@ mod test {
             };
 
             assert_eq!(msg, &[42]);
-            unwrap_result!(o.send(WriteEvent::Write(CrustMsg::Message(vec![43]))));
+            unwrap_result!(o.send(WriteEvent::Write(CrustMsg::Message(vec![43]), Instant::now())));
         });
 
-        let (mut i, o) = unwrap_result!(rendezvous_connect_utp(socket_1, addr_0,
-                                                               Duration::from_secs(HEARTBEAT_TIMEOUT_SECS),
-                                                               Duration::from_secs(INACTIVITY_TIMEOUT_SECS)));
+        let (mut i, o) =
+            unwrap_result!(rendezvous_connect_utp(socket_1,
+                                                  addr_0,
+                                                  Duration::from_secs(HEARTBEAT_TIMEOUT_SECS),
+                                                  Duration::from_secs(INACTIVITY_TIMEOUT_SECS)));
 
         let (tx, rx) = mpsc::channel();
 
         let th1 = spawn(move || {
-            o.send(WriteEvent::Write(CrustMsg::Message(vec![42])));
+            o.send(WriteEvent::Write(CrustMsg::Message(vec![42]), Instant::now()));
 
             let msg = match unwrap_result!(deserialise_from::<_, CrustMsg>(&mut i)) {
                 CrustMsg::Message(msg) => msg,


### PR DESCRIPTION
feat/connections: Drop large messages if bandwidth is insufficient.

If the upstream bandwidth is insufficient, messages stay in the sending channel for a long time. This drops messages bigger than 8 kB instead of sending them, if they are already 30 seconds old.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/664)

<!-- Reviewable:end -->
