### PR TITLE
feat/service: add network_name config option

### DIFF
--- a/installer/sample.config
+++ b/installer/sample.config
@@ -26,6 +26,7 @@
   "enable_tcp": true,
   "enable_utp": true,
   "service_discovery_port": null,
-  "bootstrap_cache_name": null
+  "bootstrap_cache_name": null,
+  "network_name": null
 }
 

--- a/src/config_handler.rs
+++ b/src/config_handler.rs
@@ -27,6 +27,7 @@ pub struct Config {
     pub tcp_mapper_servers: Vec<SocketAddr>,
     pub service_discovery_port: Option<u16>,
     pub bootstrap_cache_name: Option<String>,
+    pub network_name: Option<String>,
 }
 
 impl Default for Config {
@@ -37,6 +38,7 @@ impl Default for Config {
             tcp_mapper_servers: vec![],
             service_discovery_port: None,
             bootstrap_cache_name: None,
+            network_name: None,
         }
     }
 }


### PR DESCRIPTION
Only nodes with the same network name will connect, so that separate test networks can be set up and incompatible versions can be prevented from interfering with each other.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/681)
<!-- Reviewable:end -->
