### PR TITLE
fix/connection_states: simple_demo exception and hanging issue on Windows

### DIFF
--- a/src/connection_states/establish_connection.rs
+++ b/src/connection_states/establish_connection.rs
@@ -33,6 +33,7 @@ pub struct EstablishConnection {
     context: Context,
     routing_tx: ::CrustEventSender,
     socket: Option<TcpStream>, // Allows moving out without needing to clone the stream
+    token: Token,
 }
 
 impl EstablishConnection {
@@ -45,14 +46,15 @@ impl EstablishConnection {
 
         let context = core.get_new_context();
         let socket = TcpStream::connect(&peer_contact_info).expect("Could not connect to peer");
+        let token = core.get_new_token();
         let connection = EstablishConnection {
             cm: cm,
             context: context.clone(),
             routing_tx: routing_tx,
             socket: Some(socket),
+            token: token,
         };
 
-        let token = core.get_new_token();
         event_loop.register(connection.socket.as_ref().expect("Logic Error"),
                             token,
                             EventSet::error() | EventSet::writable(),
@@ -83,7 +85,8 @@ impl State for EstablishConnection {
                                   self.cm.clone(),
                                   self.context.clone(),
                                   self.socket.take().expect("Logic Error"),
-                                  self.routing_tx.clone());
+                                  self.routing_tx.clone(),
+                                  self.token);
         }
     }
 }


### PR DESCRIPTION
Windows doesn't allow using different token to registration to the same socket.
Windows doesn't suppot socket try_clone

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/688)

<!-- Reviewable:end -->
