### PR TITLE
feat/active_connections: Send data_len first then data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/maidsafe/crust"
 version = "0.12.0"
 
 [dependencies]
+byteorder = "~0.5.1"
 maidsafe_utilities = "~0.5.4"
 mio = "~0.5.1"
 nat_traversal = "~0.3.3"

--- a/src/connection_states/active_connection.rs
+++ b/src/connection_states/active_connection.rs
@@ -17,10 +17,11 @@
 
 use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
-use std::io::{ErrorKind, Read, Write};
+use std::io::{Cursor, ErrorKind, Read, Write};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use core::{Core, Context};
 use event::Event;
 use mio::{Token, EventLoop, EventSet, PollOpt};
@@ -28,12 +29,15 @@ use mio::tcp::TcpStream;
 use peer_id::PeerId;
 use state::State;
 
+const U32_BYTE_LENGTH: usize = 4;
+
 pub struct ActiveConnection {
     peer_id: PeerId,
     cm: Arc<Mutex<HashMap<PeerId, Context>>>,
     token: Token,
     _context: Context,
-    _read_buf: Vec<u8>,
+    read_buf: Vec<u8>,
+    read_len: u32,
     socket: TcpStream,
     write_queue: VecDeque<Vec<u8>>,
     routing_tx: ::CrustEventSender,
@@ -56,7 +60,8 @@ impl ActiveConnection {
             cm: cm,
             token: token,
             _context: context.clone(),
-            _read_buf: Vec::new(),
+            read_buf: Vec::new(),
+            read_len: 0,
             socket: socket,
             write_queue: VecDeque::new(),
             routing_tx: routing_tx,
@@ -75,10 +80,13 @@ impl ActiveConnection {
     }
 
     fn read(&mut self, _core: &mut Core, _event_loop: &mut EventLoop<Core>, _token: Token) {
-        let mut buf = vec![0; 10];
+        // the mio reading window is max at 64k (64 * 1024)
+        let mut buf = vec![0; 65536];
         match self.socket.read(&mut buf) {
-            Ok(_bytes_rxd) => {
-                let _ = self.routing_tx.send(Event::NewMessage(self.peer_id, buf));
+            Ok(bytes_rxd) => {
+                buf.resize(bytes_rxd, 0);
+                self.read_buf.append(&mut buf);
+                while self.read_data() {}
             }
             Err(e) => {
                 if !(e.kind() == ErrorKind::WouldBlock || e.kind() == ErrorKind::Interrupted) {
@@ -87,6 +95,25 @@ impl ActiveConnection {
                 }
             }
         }
+    }
+
+    fn read_data(&mut self) -> bool {
+        if self.read_len == 0 && self.read_buf.len() >= U32_BYTE_LENGTH {
+            // TODO: Gracefully exit in case of failed to parse the data_len
+            self.read_len = Cursor::new(&self.read_buf[..U32_BYTE_LENGTH])
+                    .read_u32::<LittleEndian>().expect("Failed in parsing data_len.");
+            self.read_buf = self.read_buf.split_off(U32_BYTE_LENGTH);
+        }
+        // TODO: if data_len has been incorrectly parsed, the execution hangs.
+        //       A time_out may need to be introduced to prevent it.
+        if self.read_len > 0 && self.read_buf.len() as u32 >= self.read_len {
+            let tail = self.read_buf.split_off(self.read_len as usize);
+            let _ = self.routing_tx.send(Event::NewMessage(self.peer_id, self.read_buf.clone()));
+            self.read_buf = tail;
+            self.read_len = 0;
+            return true;
+        }
+        false
     }
 
     fn write(&mut self, _core: &mut Core, event_loop: &mut EventLoop<Core>, _token: Token) {
@@ -144,6 +171,9 @@ impl State for ActiveConnection {
     }
 
     fn write(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>, data: Vec<u8>) {
+        let mut vec_len = Vec::with_capacity(U32_BYTE_LENGTH);
+        let _ = vec_len.write_u32::<LittleEndian>(data.len() as u32);
+        self.write_queue.push_back(vec_len);
         self.write_queue.push_back(data);
         let token = self.token;
         self.write(core, event_loop, token);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@
 #![cfg_attr(feature="clippy", deny(clippy, clippy_pedantic))]
 #![cfg_attr(feature="clippy", allow(use_debug))]
 
+extern crate byteorder;
 #[macro_use]
 extern crate maidsafe_utilities;
 extern crate mio;


### PR DESCRIPTION
Sending data_len first then data.
On receiving side, read size first, then reading data

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/690)

<!-- Reviewable:end -->
