### PR TITLE
feat/connection: shutdown connection in case of read error or lost peer

### DIFF
--- a/examples/simple_demo.rs
+++ b/examples/simple_demo.rs
@@ -98,12 +98,12 @@ fn main() {
             Event::NewMessage(peer_id, msg) => {
                 println!("Routing received from peer id {}: {:?}", peer_id, msg);
             }
-            Event::MessageTooLarge(peer_id, data) => {
-                println!("Routing received MessageTooLarge for data len {}", data.len());
+            Event::WriteMsgSizeProhibitive(peer_id, data) => {
+                println!("Routing received WriteMsgSizeProhibitive for data len {}", data.len());
                 service.send(peer_id, generate_random_vec_u8(10));
             }
-            Event::IncorrectDataLenPattern(peer_id) => {
-                println!("Parsed incorrect data_len during read, shut down connection {}", peer_id);
+            Event::LostPeer(peer_id) => {
+                println!("Lost Peer {}", peer_id);
                 break;
             }
             _ => {

--- a/src/event.rs
+++ b/src/event.rs
@@ -43,10 +43,8 @@ pub enum Event {
     // BootstrapFinished,
     /// Invoked as a result to the call of `Service::prepare_contact_info`.
     ConnectionInfoPrepared(ConnectionInfoResult),
-    /// Invoked when parsed incorrect data length during read
-    IncorrectDataLenPattern(PeerId),
-    // /// Invoked when a peer is lost.
-    // LostPeer(PeerId),
+    /// Invoked when a peer is lost or having read/write error.
+    LostPeer(PeerId),
     /// Invoked when a new connection get established.
     NewConnection(PeerId),
     /// Invoked when a new message is received.  Passes the message.
@@ -54,5 +52,5 @@ pub enum Event {
     // /// Invoked when a connection to a new peer is established.
     // NewPeer(io::Result<()>, PeerId),
     /// Invoked when trying to sending a too large data.
-    MessageTooLarge(PeerId, Vec<u8>),
+    WriteMsgSizeProhibitive(PeerId, Vec<u8>),
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -157,7 +157,7 @@ impl Service {
     /// sending data to a peer(according to it's u64 peer_id)
     pub fn send(&mut self, peer_id: PeerId, data: Vec<u8>) {
         if data.len() > ::MAX_DATA_LEN as usize {
-            let _ = self.event_tx.send(Event::MessageTooLarge(peer_id, data));
+            let _ = self.event_tx.send(Event::WriteMsgSizeProhibitive(peer_id, data));
             return;
         }
         let context = self.connection_map.lock().unwrap().get(&peer_id).expect("Context not found")


### PR DESCRIPTION
When reading error (parsed incorrect data_len) or lost peer, shutdown the connection and notify routing

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/694)

<!-- Reviewable:end -->
