### PR TITLE
fix/service: fix endian issue in generating network name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,25 +13,22 @@ version = "0.13.2"
 bincode = "~0.5.6"
 bufstream = "~0.1.2"
 byteorder = "~0.5.1"
+clippy = {version = "~0.0.68", optional = true}
 config_file_handler = "~0.3.0"
 crossbeam = "~0.2.9"
 get_if_addrs = "~0.4.0"
-itertools = "~0.4.13"
+itertools = "~0.4.15"
 log = "~0.3.6"
-maidsafe_utilities = "~0.5.4"
+maidsafe_utilities = "~0.6.0"
 nat_traversal = "~0.3.4"
 net2 = "~0.2.23"
-quick-error = "1.0.0"
+quick-error = "~1.0.0"
 rand = "~0.3.14"
 rustc-serialize = "~0.3.19"
 service_discovery = "~0.3.0"
 socket_addr = "~0.1.0"
 sodiumoxide = "~0.0.10"
 term = "~0.4.4"
-
-[dependencies.clippy]
-optional = true
-version = "~0.0.66"
 
 [dev-dependencies]
 docopt = "~0.6.80"


### PR DESCRIPTION
This uses the new `big_endian_sip_hash` from maidsafe_utilities to ensure all peers generate the
same name regardless of their endianness.  This also reduces the error message passed when
`connect()` fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/701)
<!-- Reviewable:end -->
