### PR TITLE
test/connection-listener: extensive test cases on all platforms & osx…

### DIFF
--- a/src/connection_listener/exchange_msg.rs
+++ b/src/connection_listener/exchange_msg.rs
@@ -186,7 +186,7 @@ impl State for ExchangeMsg {
              event_loop: &mut EventLoop<Core>,
              _token: Token,
              event_set: EventSet) {
-        if event_set.is_error() | event_set.is_hup() {
+        if event_set.is_error() || event_set.is_hup() {
             self.terminate(core, event_loop);
         } else {
             if event_set.is_readable() {
@@ -206,6 +206,7 @@ impl State for ExchangeMsg {
     }
 
     fn timeout(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>, _token: Token) {
+        debug!("Exchange message timed out. Terminating direct connection request.");
         self.terminate(core, event_loop)
     }
 


### PR DESCRIPTION
… behaviour

1) Extensively test all behaviours of connection listener including expected failure cases
2) When A and B are connected and B closes connection gracefully, A's subsequent write to B does not fail on OSX. It fails after some attempts. Read however always returns EOF on all platforms. So use that in test cases to properly validate exchange msg timeouts.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/729)

<!-- Reviewable:end -->
