### PR TITLE
refactor/connection: remove unnecessary code and state

### DIFF
--- a/src/active_connection.rs
+++ b/src/active_connection.rs
@@ -19,10 +19,10 @@ use mio::{EventLoop, EventSet, PollOpt, Timeout, TimerError, Token};
 use std::any::Any;
 
 use core::{Core, Context, State};
+use connect::SharedConnectionMap;
 use event::Event;
 use message::Message;
 use peer_id::PeerId;
-use service::SharedConnectionMap;
 use socket::Socket;
 use std::rc::Rc;
 use std::cell::RefCell;

--- a/src/active_connection.rs
+++ b/src/active_connection.rs
@@ -179,10 +179,6 @@ impl State for ActiveConnection {
     fn terminate(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>) {
         self.heartbeat.terminate(core, event_loop);
 
-        if let Err(error) = self.socket.shutdown() {
-            debug!("Failed to shutdown socket: {:?}", error);
-        }
-
         if let Err(error) = event_loop.deregister(&self.socket) {
             debug!("Failed to deregister socket: {:?}", error);
         }

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -18,28 +18,28 @@
 mod cache;
 mod try_peer;
 
-use std::net;
-use std::mem;
+use mio::{EventLoop, Timeout, Token};
+use socket_addr;
+use sodiumoxide::crypto::box_::PublicKey;
 use std::any::Any;
 use std::cell::RefCell;
+use std::collections::HashSet;
+use std::mem;
+use std::net;
 use std::rc::{Rc, Weak};
 use std::sync::mpsc::{self, Receiver};
 
-use socket_addr;
-use event::Event;
-use socket::Socket;
-use peer_id::PeerId;
-use error::CrustError;
-use self::cache::Cache;
-use config_handler::Config;
-use self::try_peer::TryPeer;
-use std::collections::HashSet;
-use core::{Context, Core, State};
-use service::SharedConnectionMap;
-use mio::{EventLoop, Timeout, Token};
-use service_discovery::ServiceDiscovery;
 use active_connection::ActiveConnection;
-use sodiumoxide::crypto::box_::PublicKey;
+use config_handler::Config;
+use connect::SharedConnectionMap;
+use core::{Context, Core, State};
+use error::CrustError;
+use event::Event;
+use peer_id::PeerId;
+use socket::Socket;
+use self::cache::Cache;
+use self::try_peer::TryPeer;
+use service_discovery::ServiceDiscovery;
 use static_contact_info::StaticContactInfo;
 
 const BOOTSTRAP_TIMEOUT_MS: u64 = 10000;

--- a/src/bootstrap/try_peer.rs
+++ b/src/bootstrap/try_peer.rs
@@ -104,7 +104,7 @@ impl TryPeer {
                 (*self.finish)(core, event_loop, context, Ok(data));
             }
             Ok(None) => (),
-            Ok(Some(_)) | Err(_) => self.handle_error(core, event_loop), // Wrong Handshake Message
+            Ok(Some(_)) | Err(_) => self.handle_error(core, event_loop),
         }
     }
 

--- a/src/connect/connection_candidate.rs
+++ b/src/connect/connection_candidate.rs
@@ -1,0 +1,186 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+use mio::{EventLoop, EventSet, PollOpt, Token};
+use std::any::Any;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use active_connection::ActiveConnection;
+use connect::SharedConnectionMap;
+use core::{Core, State};
+use event::Event;
+use message::Message;
+use peer_id::PeerId;
+use socket::Socket;
+
+pub struct ConnectionCandidate {
+    connection_map: SharedConnectionMap,
+    event_tx: ::CrustEventSender,
+    sent: bool,
+    socket: Option<Socket>,
+    their_id: PeerId,
+    token: Token,
+}
+
+impl ConnectionCandidate {
+    pub fn start(core: &mut Core,
+                 event_loop: &mut EventLoop<Core>,
+                 token: Token,
+                 socket: Socket,
+                 connection_map: SharedConnectionMap,
+                 our_id: PeerId,
+                 their_id: PeerId,
+                 event_tx: ::CrustEventSender)
+    {
+        let event_set = EventSet::error() |
+                        EventSet::hup() |
+                        EventSet::readable();
+
+        let result = if our_id > their_id {
+            event_loop.reregister(&socket, token, event_set | EventSet::writable(), PollOpt::edge())
+        } else {
+            event_loop.reregister(&socket, token, event_set, PollOpt::edge())
+        };
+
+        if let Err(error) = result {
+            error!("Failed to reregister socket: {:?}", error);
+            return;
+        }
+
+        let state = ConnectionCandidate {
+            connection_map: connection_map,
+            event_tx: event_tx,
+            sent: false,
+            socket: Some(socket),
+            their_id: their_id,
+            token: token,
+        };
+
+        let context = core.get_new_context();
+        let _ = core.insert_context(token, context);
+        let _ = core.insert_state(context, Rc::new(RefCell::new(state)));
+    }
+
+    fn readable(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>) {
+        match self.socket.as_mut().unwrap().read::<Message>() {
+            Ok(Some(Message::ChooseConnection)) => {
+                self.done(core, event_loop)
+            }
+
+            Ok(Some(message)) => {
+                warn!("Unexpected message: {:?}", message);
+                self.terminate(core, event_loop)
+            }
+
+            Ok(None) => (),
+            Err(error) => {
+                error!("Failed to read from socket: {:?}", error);
+                self.terminate(core, event_loop)
+            }
+        }
+    }
+
+    fn writable(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>) {
+        if self.connection_exists() {
+            self.terminate(core, event_loop);
+            return;
+        }
+
+        let message = if self.sent {
+            None
+        } else {
+            self.sent = true;
+            Some(Message::ChooseConnection)
+        };
+
+        match self.socket.as_mut().unwrap().write(event_loop, self.token, message) {
+            Ok(true) => self.done(core, event_loop),
+            Ok(false) => (),
+            Err(error) => {
+                error!("Failed to write to socket: {:?}", error);
+                self.terminate(core, event_loop);
+            }
+        }
+    }
+
+    fn done(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>) {
+        if self.connection_exists() {
+            self.terminate(core, event_loop);
+            return;
+        }
+
+        if let Some(context) = core.remove_context(self.token) {
+            let _ = core.remove_state(context);
+        }
+
+        let socket = self.socket.take().unwrap();
+
+        ActiveConnection::start(core,
+                                event_loop,
+                                self.token,
+                                socket,
+                                self.connection_map.clone(),
+                                self.their_id,
+                                self.event_tx.clone());
+
+        let _ = self.event_tx.send(Event::NewPeer(Ok(()), self.their_id));
+    }
+
+    fn connection_exists(&self) -> bool {
+        self.connection_map.lock().unwrap().contains_key(&self.their_id)
+    }
+}
+
+impl State for ConnectionCandidate {
+    fn ready(&mut self,
+             core: &mut Core,
+             event_loop: &mut EventLoop<Core>,
+             _token: Token,
+             event_set: EventSet)
+    {
+        if event_set.is_error() || event_set.is_hup() {
+            self.terminate(core, event_loop);
+            return;
+        }
+
+        if event_set.is_readable() {
+            self.readable(core, event_loop);
+        }
+
+        if event_set.is_writable() {
+            self.writable(core, event_loop);
+        }
+    }
+
+    fn terminate(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>) {
+        if let Some(socket) = self.socket.take() {
+            if let Err(error) = event_loop.deregister(&socket) {
+                debug!("Failed to deregister socket: {:?}", error);
+            }
+        }
+
+        if let Some(context) = core.remove_context(self.token) {
+            let _ = core.remove_state(context);
+        }
+    }
+
+    fn as_any(&mut self) -> &mut Any {
+        self
+    }
+}
+

--- a/src/connect/establish_direct_connection.rs
+++ b/src/connect/establish_direct_connection.rs
@@ -1,62 +1,239 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+use sodiumoxide::crypto::box_::PublicKey;
+use std::any::Any;
+use std::cell::RefCell;
 use std::io;
 use std::net::SocketAddr;
-use std::any::Any;
 use std::rc::Rc;
-use std::cell::RefCell;
 
-use mio::tcp::TcpStream;
 use mio::{EventSet, PollOpt, Token, EventLoop};
 
 use core::{Core, Context, State};
-use peer_id::PeerId;
+use message::Message;
+use peer_id::{self, PeerId};
+use socket::{Socket, SocketError};
 
 pub struct EstablishDirectConnection<F> {
-    stream: Option<TcpStream>,
-    finish: Option<F>,
-    token: Token,
     context: Context,
-    peer_id: PeerId,
+    finish: Option<F>,
+    name_hash: u64,
+    our_public_key: PublicKey,
+    sent: bool,
+    socket: Option<Socket>,
+    their_id: PeerId,
+    token: Token,
+    writing: bool,
 }
 
 impl<F> EstablishDirectConnection<F>
     where F: FnOnce(&mut Core,
                     &mut EventLoop<Core>,
-                    io::Result<(Token, TcpStream)>,
-                    PeerId) + Any
+                    io::Result<(Token, Socket)>) + Any
 {
     pub fn start(core: &mut Core,
                  event_loop: &mut EventLoop<Core>,
                  addr: SocketAddr,
-                 peer_id: PeerId,
-                 finish: F)
-                 -> io::Result<()> {
+                 their_id: PeerId,
+                 our_public_key: PublicKey,
+                 name_hash: u64,
+                 finish: F) {
         let token = core.get_new_token();
         let context = core.get_new_context();
 
-        let stream = try!(TcpStream::connect(&addr));
-        try!(event_loop.register(&stream,
-                                 token,
-                                 EventSet::writable() | EventSet::error(),
-                                 PollOpt::edge()));
+        let socket = match Socket::connect(&addr) {
+            Ok(socket) => socket,
+            Err(SocketError::Io(error)) => {
+                error!("Failed to connect socket: {:?}", error);
+                finish(core, event_loop, Err(error));
+                return;
+            }
+            Err(SocketError::Serialisation(_)) => unreachable!(),
+        };
+
+        let event_set = EventSet::error() | EventSet::hup() | EventSet::writable();
+        if let Err(error) = event_loop.register(&socket, token, event_set, PollOpt::edge()) {
+            error!("Failed to register socket: {:?}", error);
+            let _ = socket.shutdown();
+            finish(core, event_loop, Err(error));
+            return;
+        }
+
         let state = EstablishDirectConnection {
-            stream: Some(stream),
-            finish: Some(finish),
-            token: token,
             context: context,
-            peer_id: peer_id,
+            finish: Some(finish),
+            name_hash: name_hash,
+            our_public_key: our_public_key,
+            sent: false,
+            socket: Some(socket),
+            their_id: their_id,
+            token: token,
+            writing: false,
         };
 
         let _ = core.insert_context(token, context);
         let _ = core.insert_state(context, Rc::new(RefCell::new(state)));
-        Ok(())
+    }
+
+    fn writable(&mut self,
+                core: &mut Core,
+                event_loop: &mut EventLoop<Core>)
+    {
+        let result = if self.writing {
+            self.socket.as_mut().unwrap().flush()
+        } else {
+            self.writing = true;
+            self.socket.as_mut()
+                       .unwrap()
+                       .write(Message::Connect(self.our_public_key, self.name_hash))
+        };
+
+        match result {
+            Ok(true) => self.handle_connect_sent(core, event_loop),
+            Ok(false) => self.reregister(core, event_loop, true),
+            Err(error) => {
+                error!("Failed to write to socket: {:?}", error);
+                self.done(core, event_loop, Err(make_io_error(error)));
+                return;
+            }
+        }
+    }
+
+    fn readable(&mut self,
+                core: &mut Core,
+                event_loop: &mut EventLoop<Core>)
+    {
+        match self.socket.as_mut().unwrap().read::<Message>() {
+            Ok(Some(Message::Connect(public_key, name_hash))) => {
+                self.handle_connect_received(core,
+                                             event_loop,
+                                             public_key,
+                                             name_hash)
+            }
+
+            Ok(Some(message)) => {
+                warn!("Unexpected message: {:?}", message);
+                self.reregister(core, event_loop, false)
+            }
+
+            Ok(None) => {
+                self.reregister(core, event_loop, false)
+            }
+
+            Err(error) => {
+                error!("Failed to read from socket: {:?}", error);
+                self.done(core, event_loop, Err(make_io_error(error)))
+            }
+        }
+    }
+
+    fn handle_connect_received(&mut self,
+                               core: &mut Core,
+                               event_loop: &mut EventLoop<Core>,
+                               their_public_key: PublicKey,
+                               name_hash: u64)
+    {
+        if name_hash != self.name_hash {
+            let error = io::Error::new(io::ErrorKind::Other, "Incompatible protocol version");
+            self.done(core, event_loop, Err(error));
+            return;
+        }
+
+        if their_public_key == self.our_public_key {
+            let error = io::Error::new(io::ErrorKind::Other, "Connecting to ourselves");
+            self.done(core, event_loop, Err(error));
+            return;
+        }
+
+        if self.our_id() < self.their_id {
+            let token = self.token;
+            let socket = self.socket.take().unwrap();
+            self.done(core, event_loop, Ok((token, socket)))
+        } else {
+            self.writing = false;
+            self.reregister(core, event_loop, true)
+        }
+    }
+
+    fn handle_connect_sent(&mut self,
+                           core: &mut Core,
+                           event_loop: &mut EventLoop<Core>)
+    {
+        if self.our_id() < self.their_id {
+            self.reregister(core, event_loop, false)
+        } else if self.sent {
+            let token = self.token;
+            let socket = self.socket.take().unwrap();
+            self.done(core, event_loop, Ok((token, socket)))
+        } else {
+            self.sent = true;
+            self.reregister(core, event_loop, false)
+        }
+    }
+
+    fn reregister(&mut self,
+                  core: &mut Core,
+                  event_loop: &mut EventLoop<Core>,
+                  writable: bool) {
+        let mut event_set = EventSet::error() | EventSet::hup() | EventSet::readable();
+        if writable {
+            event_set.insert(EventSet::writable())
+        }
+
+        let result = event_loop.reregister(self.socket.as_ref().unwrap(),
+                                           self.token,
+                                           event_set,
+                                           PollOpt::edge());
+
+        if let Err(error) = result {
+            error!("Failed to reregister socket: {:?}", error);
+            self.done(core, event_loop, Err(error));
+        }
+    }
+
+    fn done(&mut self,
+            core: &mut Core,
+            event_loop: &mut EventLoop<Core>,
+            result: io::Result<(Token, Socket)>)
+    {
+        let _ = core.remove_state(self.context);
+        let _ = core.remove_context(self.token);
+
+        if let Some(socket) = self.socket.take() {
+            match event_loop.deregister(&socket) {
+                Ok(()) => (),
+                Err(e) => debug!("Failed to deregister socket: {}", e),
+            };
+        }
+
+        let finish = self.finish.take().unwrap();
+        finish(core, event_loop, result);
+    }
+
+    fn our_id(&self) -> PeerId {
+        peer_id::new(self.our_public_key)
     }
 }
 
 impl<F> State for EstablishDirectConnection<F>
     where F: FnOnce(&mut Core,
                     &mut EventLoop<Core>,
-                    io::Result<(Token, TcpStream)>,
-                    PeerId) + Any
+                    io::Result<(Token, Socket)>) + Any
 {
     fn ready(&mut self,
              core: &mut Core,
@@ -64,41 +241,43 @@ impl<F> State for EstablishDirectConnection<F>
              _token: Token,
              event_set: EventSet) {
         if event_set.is_error() {
-            let _ = core.remove_state(self.context);
-            let _ = core.remove_context(self.token);
-            let finish = self.finish.take().unwrap();
-            let stream = self.stream.take().unwrap();
-            match event_loop.deregister(&stream) {
-                Ok(()) => (),
-                Err(e) => debug!("Error deregistering stream: {}", e),
-            };
-            let error = match stream.take_socket_error() {
+            let error = match self.socket.as_ref()
+                                         .unwrap()
+                                         .take_socket_error() {
                 Ok(()) => io::Error::new(io::ErrorKind::Other, "Unknown error"),
                 Err(e) => e,
             };
-            finish(core, event_loop, Err(error), self.peer_id);
-        } else if event_set.is_writable() {
-            let _ = core.remove_state(self.context);
-            let finish = self.finish.take().unwrap();
-            let stream = self.stream.take().unwrap();
-            finish(core, event_loop, Ok((self.token, stream)), self.peer_id);
+
+            self.done(core, event_loop, Err(error));
+        } else if event_set.is_hup() {
+            let error = io::Error::new(io::ErrorKind::ConnectionAborted, "Connection aborted");
+            self.done(core, event_loop, Err(error));
+        } else {
+            if event_set.is_readable() {
+                self.readable(core, event_loop)
+            }
+
+            if event_set.is_writable() {
+                self.writable(core, event_loop)
+            }
         }
     }
 
     fn terminate(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>) {
-        let _ = core.remove_state(self.context);
-        let _ = core.remove_context(self.token);
-        let stream = self.stream.take().unwrap();
-        match event_loop.deregister(&stream) {
-            Ok(()) => (),
-            Err(e) => debug!("Error deregistering stream: {}", e),
-        };
-        let finish = self.finish.take().unwrap();
-        let error = io::Error::new(io::ErrorKind::Other, "Connect cancelled");
-        finish(core, event_loop, Err(error), self.peer_id);
+        let result = Err(io::Error::new(io::ErrorKind::Other, "Connect cancelled"));
+        self.done(core, event_loop, result);
     }
 
     fn as_any(&mut self) -> &mut Any {
         self
+    }
+}
+
+fn make_io_error(error: SocketError) -> io::Error {
+    match error {
+        SocketError::Io(error) => error,
+        SocketError::Serialisation(error) => {
+            io::Error::new(io::ErrorKind::Other, error)
+        }
     }
 }

--- a/src/connect/establish_direct_connection.rs
+++ b/src/connect/establish_direct_connection.rs
@@ -24,22 +24,18 @@ use std::rc::Rc;
 
 use mio::{EventSet, PollOpt, Token, EventLoop};
 
-use core::{Core, Context, State};
+use core::{Core, State};
 use error::CrustError;
 use message::Message;
-use peer_id::{self, PeerId};
 use socket::Socket;
 
 pub struct EstablishDirectConnection<F> {
-    context: Context,
     finish: Option<F>,
     name_hash: u64,
     our_public_key: PublicKey,
     sent: bool,
     socket: Option<Socket>,
-    their_id: PeerId,
     token: Token,
-    writing: bool,
 }
 
 impl<F> EstablishDirectConnection<F>
@@ -50,12 +46,9 @@ impl<F> EstablishDirectConnection<F>
     pub fn start(core: &mut Core,
                  event_loop: &mut EventLoop<Core>,
                  addr: SocketAddr,
-                 their_id: PeerId,
                  our_public_key: PublicKey,
                  name_hash: u64,
                  finish: F) {
-        let token = core.get_new_token();
-        let context = core.get_new_context();
 
         let socket = match Socket::connect(&addr) {
             Ok(socket) => socket,
@@ -67,6 +60,7 @@ impl<F> EstablishDirectConnection<F>
             Err(_) => unreachable!(),
         };
 
+        let token = core.get_new_token();
         let event_set = EventSet::error() | EventSet::hup() | EventSet::writable();
         if let Err(error) = event_loop.register(&socket, token, event_set, PollOpt::edge()) {
             error!("Failed to register socket: {:?}", error);
@@ -76,17 +70,15 @@ impl<F> EstablishDirectConnection<F>
         }
 
         let state = EstablishDirectConnection {
-            context: context,
             finish: Some(finish),
             name_hash: name_hash,
             our_public_key: our_public_key,
             sent: false,
             socket: Some(socket),
-            their_id: their_id,
             token: token,
-            writing: false,
         };
 
+        let context = core.get_new_context();
         let _ = core.insert_context(token, context);
         let _ = core.insert_state(context, Rc::new(RefCell::new(state)));
     }
@@ -95,22 +87,20 @@ impl<F> EstablishDirectConnection<F>
                 core: &mut Core,
                 event_loop: &mut EventLoop<Core>)
     {
-        let result = if self.writing {
-            self.socket.as_mut().unwrap().flush()
+        let message = if self.sent {
+            None
         } else {
-            self.writing = true;
-            self.socket.as_mut()
-                       .unwrap()
-                       .write(Message::Connect(self.our_public_key, self.name_hash))
+            self.sent = true;
+            Some(Message::Connect(self.our_public_key, self.name_hash))
         };
 
-        match result {
-            Ok(true) => self.handle_connect_sent(core, event_loop),
-            Ok(false) => self.reregister(core, event_loop, true),
+        match self.socket.as_mut()
+                         .unwrap()
+                         .write(event_loop, self.token, message) {
+            Ok(_) => (),
             Err(error) => {
                 error!("Failed to write to socket: {:?}", error);
                 self.done(core, event_loop, Err(make_io_error(error)));
-                return;
             }
         }
     }
@@ -121,33 +111,31 @@ impl<F> EstablishDirectConnection<F>
     {
         match self.socket.as_mut().unwrap().read::<Message>() {
             Ok(Some(Message::Connect(public_key, name_hash))) => {
-                self.handle_connect_received(core,
-                                             event_loop,
-                                             public_key,
-                                             name_hash)
+                self.handle_connect(core,
+                                    event_loop,
+                                    public_key,
+                                    name_hash);
             }
 
             Ok(Some(message)) => {
-                warn!("Unexpected message: {:?}", message);
-                self.reregister(core, event_loop, false)
+                let error = io::Error::new(io::ErrorKind::Other,
+                                           format!("Unexpected message: {:?}", message));
+                self.done(core, event_loop, Err(error));
             }
 
-            Ok(None) => {
-                self.reregister(core, event_loop, false)
-            }
-
+            Ok(None) => (),
             Err(error) => {
                 error!("Failed to read from socket: {:?}", error);
-                self.done(core, event_loop, Err(make_io_error(error)))
+                self.done(core, event_loop, Err(make_io_error(error)));
             }
         }
     }
 
-    fn handle_connect_received(&mut self,
-                               core: &mut Core,
-                               event_loop: &mut EventLoop<Core>,
-                               their_public_key: PublicKey,
-                               name_hash: u64)
+    fn handle_connect(&mut self,
+                      core: &mut Core,
+                      event_loop: &mut EventLoop<Core>,
+                      their_public_key: PublicKey,
+                      name_hash: u64)
     {
         if name_hash != self.name_hash {
             let error = io::Error::new(io::ErrorKind::Other, "Incompatible protocol version");
@@ -161,50 +149,9 @@ impl<F> EstablishDirectConnection<F>
             return;
         }
 
-        if self.our_id() < self.their_id {
-            let token = self.token;
-            let socket = self.socket.take().unwrap();
-            self.done(core, event_loop, Ok((token, socket)))
-        } else {
-            self.writing = false;
-            self.reregister(core, event_loop, true)
-        }
-    }
-
-    fn handle_connect_sent(&mut self,
-                           core: &mut Core,
-                           event_loop: &mut EventLoop<Core>)
-    {
-        if self.our_id() < self.their_id {
-            self.reregister(core, event_loop, false)
-        } else if self.sent {
-            let token = self.token;
-            let socket = self.socket.take().unwrap();
-            self.done(core, event_loop, Ok((token, socket)))
-        } else {
-            self.sent = true;
-            self.reregister(core, event_loop, false)
-        }
-    }
-
-    fn reregister(&mut self,
-                  core: &mut Core,
-                  event_loop: &mut EventLoop<Core>,
-                  writable: bool) {
-        let mut event_set = EventSet::error() | EventSet::hup() | EventSet::readable();
-        if writable {
-            event_set.insert(EventSet::writable())
-        }
-
-        let result = event_loop.reregister(self.socket.as_ref().unwrap(),
-                                           self.token,
-                                           event_set,
-                                           PollOpt::edge());
-
-        if let Err(error) = result {
-            error!("Failed to reregister socket: {:?}", error);
-            self.done(core, event_loop, Err(error));
-        }
+        let token = self.token;
+        let socket = self.socket.take().unwrap();
+        self.done(core, event_loop, Ok((token, socket)))
     }
 
     fn done(&mut self,
@@ -212,22 +159,18 @@ impl<F> EstablishDirectConnection<F>
             event_loop: &mut EventLoop<Core>,
             result: io::Result<(Token, Socket)>)
     {
-        let _ = core.remove_state(self.context);
-        let _ = core.remove_context(self.token);
+        if let Some(context) = core.remove_context(self.token) {
+            let _ = core.remove_state(context);
+        }
 
         if let Some(socket) = self.socket.take() {
-            match event_loop.deregister(&socket) {
-                Ok(()) => (),
-                Err(e) => debug!("Failed to deregister socket: {}", e),
-            };
+            if let Err(error) = event_loop.deregister(&socket) {
+                debug!("Failed to deregister socket: {}", error);
+            }
         }
 
         let finish = self.finish.take().unwrap();
         finish(core, event_loop, result);
-    }
-
-    fn our_id(&self) -> PeerId {
-        peer_id::new(self.our_public_key)
     }
 }
 

--- a/src/connect/mod.rs
+++ b/src/connect/mod.rs
@@ -15,8 +15,8 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+mod connection_candidate;
 mod establish_direct_connection;
-// mod send_direct_info;
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -24,8 +24,8 @@ use std::sync::{Arc, Mutex};
 use core::Context;
 use peer_id::PeerId;
 
+pub use self::connection_candidate::ConnectionCandidate;
 pub use self::establish_direct_connection::EstablishDirectConnection;
 
 pub type ConnectionMap = HashMap<PeerId, Context>;
 pub type SharedConnectionMap = Arc<Mutex<ConnectionMap>>;
-

--- a/src/connect/mod.rs
+++ b/src/connect/mod.rs
@@ -1,2 +1,31 @@
-pub mod establish_direct_connection;
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+mod establish_direct_connection;
 // mod send_direct_info;
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use core::Context;
+use peer_id::PeerId;
+
+pub use self::establish_direct_connection::EstablishDirectConnection;
+
+pub type ConnectionMap = HashMap<PeerId, Context>;
+pub type SharedConnectionMap = Arc<Mutex<ConnectionMap>>;
+

--- a/src/connection_listener/exchange_msg.rs
+++ b/src/connection_listener/exchange_msg.rs
@@ -76,7 +76,7 @@ impl ExchangeMsg {
         Ok(())
     }
 
-    fn readable(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>) {
+    fn read(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>) {
         match self.socket.as_mut().unwrap().read::<Message>() {
             Ok(Some(Message::BootstrapRequest(their_public_key, name_hash))) => {
                 self.handle_bootstrap_request(core, event_loop, their_public_key, name_hash)
@@ -94,10 +94,6 @@ impl ExchangeMsg {
                 self.terminate(core, event_loop);
             }
         }
-    }
-
-    fn writable(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>) {
-        let _ = self.write(core, event_loop, None);
     }
 
     fn handle_bootstrap_request(&mut self,
@@ -209,10 +205,10 @@ impl State for ExchangeMsg {
             self.terminate(core, event_loop);
         } else {
             if event_set.is_readable() {
-                self.readable(core, event_loop)
+                self.read(core, event_loop)
             }
             if event_set.is_writable() {
-                self.writable(core, event_loop)
+                self.write(core, event_loop, None)
             }
         }
     }

--- a/src/connection_listener/exchange_msg.rs
+++ b/src/connection_listener/exchange_msg.rs
@@ -22,11 +22,11 @@ use std::io::{self, ErrorKind};
 use std::rc::Rc;
 
 use active_connection::ActiveConnection;
+use connect::SharedConnectionMap;
 use core::{Context, Core, State};
 use event::Event;
 use message::Message;
 use peer_id::{self, PeerId};
-use service::SharedConnectionMap;
 use socket::Socket;
 use sodiumoxide::crypto::box_::PublicKey;
 
@@ -39,10 +39,11 @@ pub struct ExchangeMsg {
     event: Option<Event>,
     event_tx: ::CrustEventSender,
     name_hash: u64,
-    our_pk: PublicKey,
-    peer_id: Option<PeerId>,
+    our_public_key: PublicKey,
     socket: Option<Socket>,
+    their_id: Option<PeerId>,
     timeout: Timeout,
+    token: Token,
 }
 
 impl ExchangeMsg {
@@ -184,7 +185,6 @@ impl ExchangeMsg {
             warn!("Already connected to {:?}", peer_id);
             return Err(());
         }
-    }
 
         Ok(peer_id)
     }

--- a/src/connection_listener/mod.rs
+++ b/src/connection_listener/mod.rs
@@ -24,7 +24,6 @@ use socket_addr;
 use sodiumoxide::crypto::box_::PublicKey;
 use std::any::Any;
 use std::cell::RefCell;
-use std::io;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
@@ -179,7 +178,7 @@ mod test {
     use std::time::Duration;
     use std::sync::{Arc, Mutex};
     use std::collections::HashMap;
-    use std::io::{self, Cursor, Write, Read};
+    use std::io::{Cursor, Write, Read};
     use std::net::SocketAddr as StdSocketAddr;
 
     use event::Event;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,10 @@ extern crate crossbeam;
 #[cfg(test)]
 extern crate void;
 
+#[cfg(test)]
+#[macro_use]
+mod tests;
+
 mod connect;
 mod active_connection;
 mod bootstrap;
@@ -84,8 +88,6 @@ mod socket;
 mod static_contact_info;
 pub mod nat;
 
-#[cfg(test)]
-mod tests;
 
 /// Crust Observers will be informed of crust events on this
 pub type CrustEventSender = ::maidsafe_utilities::event_sender::MaidSafeObserver<Event>;

--- a/src/message.rs
+++ b/src/message.rs
@@ -24,8 +24,7 @@ pub enum Message {
     BootstrapResponse(PublicKey),
     // ExternalEndpointRequest,
     // ExternalEndpointResponse(SocketAddr),
+    ChooseConnection,
     Connect(PublicKey, u64),
-    // DuplicateConnectionRequest,
-    // DuplicateConnectionResponse,
     Data(Vec<u8>),
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -489,75 +489,32 @@ fn name_hash(network_name: &Option<String>) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::mpsc::Receiver;
-    use std::sync::mpsc;
-    use std::time::Duration;
-    use std::thread;
-    use std::iter;
-
-    use maidsafe_utilities::event_sender::{MaidSafeObserver, MaidSafeEventCategory};
-    use void::Void;
-    use crossbeam;
+    use maidsafe_utilities::log;
     use rand;
+    use std::time::Duration;
+    use std::iter;
 
     use event::Event;
     use service::Service;
-
-    fn get_event_sender
-        ()
-        -> (::CrustEventSender, Receiver<MaidSafeEventCategory>, Receiver<Event>)
-    {
-        let (category_tx, category_rx) = mpsc::channel();
-        let event_category = MaidSafeEventCategory::Crust;
-        let (event_tx, event_rx) = mpsc::channel();
-
-        (MaidSafeObserver::new(event_tx, event_category, category_tx), category_rx, event_rx)
-    }
-
-    fn timebomb<R, F>(dur: Duration, f: F) -> R
-        where R: Send,
-              F: Send + FnOnce() -> R
-    {
-        crossbeam::scope(|scope| {
-            let thread_handle = thread::current();
-            let (done_tx, done_rx) = mpsc::channel::<Void>();
-            let jh = scope.spawn(move || {
-                let ret = f();
-                drop(done_tx);
-                thread_handle.unpark();
-                ret
-            });
-            thread::park_timeout(dur);
-            match done_rx.try_recv() {
-                Ok(x) => match x {},
-                Err(mpsc::TryRecvError::Empty) => panic!("Timed out!"),
-                Err(mpsc::TryRecvError::Disconnected) => jh.join(),
-            }
-        })
-    }
+    use tests::{get_event_sender, timebomb};
 
     #[test]
     #[ignore]
     fn connect_two_peers() {
+        unwrap_result!(log::init(true));
+
         timebomb(Duration::from_secs(5), || {
-            let (event_tx_0, _category_rx_0, event_rx_0) = get_event_sender();
+            let (event_tx_0, event_rx_0) = get_event_sender();
             let mut service_0 = unwrap_result!(Service::new(event_tx_0));
 
-            let (event_tx_1, _category_rx_1, event_rx_1) = get_event_sender();
+            let (event_tx_1, event_rx_1) = get_event_sender();
             let mut service_1 = unwrap_result!(Service::new(event_tx_1));
 
             service_0.prepare_connection_info(0);
             service_1.prepare_connection_info(0);
 
-            let conn_info_result_0 = match unwrap_result!(event_rx_0.recv()) {
-                Event::ConnectionInfoPrepared(conn_info_result) => conn_info_result,
-                e => panic!("Unexpected message type: {:?}", e),
-            };
-
-            let conn_info_result_1 = match unwrap_result!(event_rx_1.recv()) {
-                Event::ConnectionInfoPrepared(conn_info_result) => conn_info_result,
-                e => panic!("Unexpected message type: {:?}", e),
-            };
+            let conn_info_result_0 = expect_event!(event_rx_0, Event::ConnectionInfoPrepared(result) => result);
+            let conn_info_result_1 = expect_event!(event_rx_1, Event::ConnectionInfoPrepared(result) => result);
 
             let pub_info_0 = unwrap_result!(conn_info_result_0.result);
             let pub_info_1 = unwrap_result!(conn_info_result_1.result);
@@ -567,20 +524,15 @@ mod tests {
             unwrap_result!(service_0.connect(pub_info_0, priv_info_1));
             unwrap_result!(service_1.connect(pub_info_1, priv_info_0));
 
-            let id_1 = match unwrap_result!(event_rx_0.recv()) {
-                Event::NewPeer(res, id) => {
-                    unwrap_result!(res);
-                    id
-                }
-                e => panic!("Unexpected event when waiting for NewPeer: {:?}", e),
-            };
-            let id_0 = match unwrap_result!(event_rx_1.recv()) {
-                Event::NewPeer(res, id) => {
-                    unwrap_result!(res);
-                    id
-                }
-                e => panic!("Unexpected event when waiting for NewPeer: {:?}", e),
-            };
+            let id_1 = expect_event!(event_rx_0, Event::NewPeer(res, id) => {
+                unwrap_result!(res);
+                id
+            });
+
+            let id_0 = expect_event!(event_rx_1, Event::NewPeer(res, id) => {
+                unwrap_result!(res);
+                id
+            });
 
             let data_0: Vec<u8> = iter::repeat(()).take(32).map(|()| rand::random()).collect();
             let send_0 = data_0.clone();
@@ -589,20 +541,15 @@ mod tests {
             unwrap_result!(service_0.send(id_1, data_0, 0));
             unwrap_result!(service_1.send(id_0, data_1, 0));
 
-            let recv_1 = match unwrap_result!(event_rx_0.recv()) {
-                Event::NewMessage(id, recv) => {
-                    assert_eq!(id, id_1);
-                    recv
-                }
-                e => panic!("Unexpected event when waiting for NewMessage: {:?}", e),
-            };
-            let recv_0 = match unwrap_result!(event_rx_1.recv()) {
-                Event::NewMessage(id, recv) => {
-                    assert_eq!(id, id_0);
-                    recv
-                }
-                e => panic!("Unexpected event when waiting for NewMessage: {:?}", e),
-            };
+            let recv_1 = expect_event!(event_rx_0, Event::NewMessage(id, recv) => {
+                assert_eq!(id, id_1);
+                recv
+            });
+
+            let recv_0 = expect_event!(event_rx_1, Event::NewMessage(id, recv) => {
+                assert_eq!(id, id_0);
+                recv
+            });
 
             assert_eq!(recv_0, send_0);
             assert_eq!(recv_1, send_1);

--- a/src/service.rs
+++ b/src/service.rs
@@ -295,6 +295,7 @@ impl Service {
                         Ok((token, socket)) => {
                             let event_tx = (&*event_tx_rc).clone();
 
+                            println!("DIRECT {:?}", their_id);
                             ActiveConnection::start(core,
                                                     event_loop,
                                                     token,
@@ -343,6 +344,7 @@ impl Service {
                             let socket = Socket::wrap(stream);
                             let event_tx = (&*event_tx_rc).clone();
 
+                            println!("HOLE PUNCH {:?}", their_id);
                             ActiveConnection::start(core,
                                                     event_loop,
                                                     token,
@@ -366,21 +368,10 @@ impl Service {
         });
 
         Ok(())
-        // let event_tx = self.event_tx.clone();
-        // let connection_map = self.connection_map.clone();
-        //
-        // self.post(move |core, event_loop| {
-        // EstablishConnection::start(core,
-        // event_loop,
-        // peer_contact_info,
-        // connection_map,
-        // event_tx);
-        // })
-        //
     }
 
     /// Disconnect from the given peer and returns whether there was a connection at all.
-    pub fn disconnect(&mut self, peer_id: PeerId) -> bool {
+    pub fn disconnect(&self, peer_id: PeerId) -> bool {
         let context = match self.connection_map.lock().unwrap().remove(&peer_id) {
             Some(context) => context,
             None => return false,

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -181,6 +181,10 @@ impl Socket {
     pub fn shutdown(&self) -> ::Res<()> {
         Ok(try!(self.stream.shutdown(Shutdown::Both)))
     }
+
+    pub fn take_socket_error(&self) -> io::Result<()> {
+        self.stream.take_socket_error()
+    }
 }
 
 impl Evented for Socket {

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -128,7 +128,8 @@ impl Socket {
     pub fn write<T: Encodable>(&mut self,
                                el: &mut EventLoop<Core>,
                                token: Token,
-                               msg: Option<T>) -> ::Res<bool> {
+                               msg: Option<T>)
+                               -> ::Res<bool> {
         if let Some(msg) = msg {
             let mut data = Cursor::new(Vec::with_capacity(mem::size_of::<u32>()));
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -15,12 +15,13 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use maidsafe_utilities::event_sender::{MaidSafeObserver, MaidSafeEventCategory};
+#[macro_use]
+pub mod utils;
+
 // use maidsafe_utilities::log;
 use std::net::SocketAddr as StdSocketAddr;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
-use std::sync::mpsc::{self, Receiver};
 
 use config_handler::Config;
 use event::Event;
@@ -28,12 +29,7 @@ use service::Service;
 use socket_addr::SocketAddr;
 use static_contact_info::StaticContactInfo;
 
-fn get_event_sender() -> (::CrustEventSender, Receiver<Event>) {
-    let (category_tx, _) = mpsc::channel();
-    let (event_tx, event_rx) = mpsc::channel();
-
-    (MaidSafeObserver::new(event_tx, MaidSafeEventCategory::Crust, category_tx), event_rx)
-}
+pub use self::utils::{get_event_sender, timebomb};
 
 fn localhost(port: u16) -> SocketAddr {
     use std::net::IpAddr;
@@ -67,25 +63,6 @@ fn gen_config() -> Config {
     config.bootstrap_cache_name = Some(gen_bootstrap_cache_name());
     config
 }
-
-// Receive an event from the given receiver and asserts that it matches the
-// given pattern.
-macro_rules! expect_event {
-    ($rx:expr, $pattern:pat) => {
-        match unwrap_result!($rx.recv()) {
-            $pattern => (),
-            e => panic!("unexpected event {:?}", e),
-        }
-    };
-
-    ($rx:expr, $pattern:pat => $arm:expr) => {
-        match unwrap_result!($rx.recv()) {
-            $pattern => $arm,
-            e => panic!("unexpected event {:?}", e),
-        }
-    }
-}
-
 
 #[test]
 fn bootstrap_two_services_and_exchange_messages() {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -29,7 +29,7 @@ use service::Service;
 use socket_addr::SocketAddr;
 use static_contact_info::StaticContactInfo;
 
-pub use self::utils::{get_event_sender, timebomb};
+pub use self::utils::{gen_config, get_event_sender, timebomb};
 
 fn localhost(port: u16) -> SocketAddr {
     use std::net::IpAddr;
@@ -43,25 +43,11 @@ fn localhost_contact_info(port: u16) -> StaticContactInfo {
     }
 }
 
-// Generate unique name for the bootstrap cache.
-fn gen_bootstrap_cache_name() -> String {
-    static COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
-    format!("test{}.bootstrap.cache",
-            COUNTER.fetch_add(1, Ordering::Relaxed))
-}
-
 fn gen_service_discovery_port() -> u16 {
     const BASE: u16 = 40000;
     static COUNTER: AtomicUsize = ATOMIC_USIZE_INIT;
 
     BASE + COUNTER.fetch_add(1, Ordering::Relaxed) as u16
-}
-
-// Generate config with unique bootstrap cache name.
-fn gen_config() -> Config {
-    let mut config = Config::default();
-    config.bootstrap_cache_name = Some(gen_bootstrap_cache_name());
-    config
 }
 
 #[test]

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -1,0 +1,72 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+use crossbeam;
+use maidsafe_utilities::event_sender::{MaidSafeObserver, MaidSafeEventCategory};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+use std::time::Duration;
+use void::Void;
+
+use event::Event;
+
+// Receive an event from the given receiver and asserts that it matches the
+// given pattern.
+macro_rules! expect_event {
+    ($rx:expr, $pattern:pat) => {
+        match unwrap_result!($rx.recv()) {
+            $pattern => (),
+            e => panic!("unexpected event {:?}", e),
+        }
+    };
+
+    ($rx:expr, $pattern:pat => $arm:expr) => {
+        match unwrap_result!($rx.recv()) {
+            $pattern => $arm,
+            e => panic!("unexpected event {:?}", e),
+        }
+    }
+}
+
+pub fn get_event_sender() -> (::CrustEventSender, Receiver<Event>) {
+    let (category_tx, _) = mpsc::channel();
+    let (event_tx, event_rx) = mpsc::channel();
+
+    (MaidSafeObserver::new(event_tx, MaidSafeEventCategory::Crust, category_tx), event_rx)
+}
+
+pub fn timebomb<R, F>(dur: Duration, f: F) -> R
+    where R: Send,
+          F: Send + FnOnce() -> R
+{
+    crossbeam::scope(|scope| {
+        let thread_handle = thread::current();
+        let (done_tx, done_rx) = mpsc::channel::<Void>();
+        let jh = scope.spawn(move || {
+            let ret = f();
+            drop(done_tx);
+            thread_handle.unpark();
+            ret
+        });
+        thread::park_timeout(dur);
+        match done_rx.try_recv() {
+            Ok(x) => match x {},
+            Err(mpsc::TryRecvError::Empty) => panic!("Timed out!"),
+            Err(mpsc::TryRecvError::Disconnected) => jh.join(),
+        }
+    })
+}


### PR DESCRIPTION
1) Remove unnecessary code and event registrations
2) Remove unneeded states due to above (e.g. `sent` in `ConnectionCandidate`)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/737)

<!-- Reviewable:end -->
