### PR TITLE
Crust error to io error

### DIFF
--- a/examples/mapping_client.rs
+++ b/examples/mapping_client.rs
@@ -18,7 +18,7 @@ use crust::nat::mapped_tcp_socket::MappingTcpSocket;
 use crust::nat::mapping_context::MappingContext;
 use crust::nat::punch_hole::PunchHole;
 use crust::nat::rendezvous_info::gen_rendezvous_info;
-use mio::{EventLoop, EventSet, Token, PollOpt};
+use mio::{EventLoop, EventSet, Token};
 use mio::{TryRead, TryWrite};
 use mio::tcp::TcpStream;
 use socket_addr::SocketAddr;
@@ -118,8 +118,8 @@ fn main() {
 
         let res = PunchHole::start(core, event_loop, socket, our_priv_info, their_pub_info,
                                   |core, event_loop, stream_opt| {
-            let mut stream = match stream_opt {
-                Some(stream) => stream,
+            let (mut stream, token) = match stream_opt {
+                Some(x) => x,
                 None => {
                     println!("Failed to punch hole");
                     return;
@@ -136,7 +136,7 @@ fn main() {
                 },
             };
 
-            MessageReader::start(core, event_loop, stream);
+            MessageReader::start(core, event_loop, stream, token);
             
             /*
             let token = core.get_new_token();
@@ -162,16 +162,8 @@ struct MessageReader {
 }
 
 impl MessageReader {
-    pub fn start(core: &mut Core, event_loop: &mut EventLoop<Core>, stream: TcpStream) {
-        let token = core.get_new_token();
+    pub fn start(core: &mut Core, _event_loop: &mut EventLoop<Core>, stream: TcpStream, token: Token) {
         let context = core.get_new_context();
-        match event_loop.register(&stream, token, EventSet::readable(), PollOpt::edge()) {
-            Ok(()) => (),
-            Err(e) => {
-                println!("Error registering socket: {}", e);
-                return;
-            }
-        }
         let _ = core.insert_context(token, context.clone());
         let _ = core.insert_state(context,
                                   Rc::new(RefCell::new(MessageReader { stream: stream })));

--- a/examples/mapping_client.rs
+++ b/examples/mapping_client.rs
@@ -3,6 +3,8 @@ extern crate mio;
 extern crate env_logger;
 extern crate socket_addr;
 extern crate rustc_serialize;
+#[macro_use]
+extern crate log;
 
 use std::net;
 use std::net::{ToSocketAddrs, SocketAddrV4, Ipv4Addr};
@@ -180,8 +182,9 @@ impl State for MessageReader {
     fn ready(&mut self,
              _core: &mut Core,
              _event_loop: &mut EventLoop<Core>,
-             _token: Token,
-             _event_set: EventSet) {
+             token: Token,
+             event_set: EventSet) {
+        debug!("MessageReader ready: {:?} {:?}", token, event_set);
         let mut buf = [0u8; 256];
         match self.stream.try_read(&mut buf[..]) {
             Ok(Some(n)) => {
@@ -196,7 +199,7 @@ impl State for MessageReader {
                     }
                 }
             }
-            Ok(None) => (),
+            Ok(None) => debug!("Stream wasn't ready"),
             Err(e) => {
                 println!("Error receiving message from peer: {}", e);
             }

--- a/src/connect/establish_direct_connection.rs
+++ b/src/connect/establish_direct_connection.rs
@@ -100,7 +100,7 @@ impl<F> EstablishDirectConnection<F>
             Ok(_) => (),
             Err(error) => {
                 error!("Failed to write to socket: {:?}", error);
-                self.done(core, event_loop, Err(make_io_error(error)));
+                self.done(core, event_loop, Err(From::from(error)));
             }
         }
     }
@@ -126,7 +126,7 @@ impl<F> EstablishDirectConnection<F>
             Ok(None) => (),
             Err(error) => {
                 error!("Failed to read from socket: {:?}", error);
-                self.done(core, event_loop, Err(make_io_error(error)));
+                self.done(core, event_loop, Err(From::from(error)));
             }
         }
     }
@@ -217,10 +217,3 @@ impl<F> State for EstablishDirectConnection<F>
     }
 }
 
-fn make_io_error(error: CrustError) -> io::Error {
-    match error {
-        CrustError::Io(error) => error,
-        CrustError::Serialisation(error) => io::Error::new(io::ErrorKind::Other, error),
-        _ => unreachable!(),
-    }
-}

--- a/src/error.rs
+++ b/src/error.rs
@@ -89,3 +89,43 @@ quick_error! {
         }
     }
 }
+
+impl From<CrustError> for io::Error {
+    fn from(err: CrustError) -> io::Error {
+        match err {
+            CrustError::Io(e) => e,
+            CrustError::MioNotify(e) => match e {
+                mio::NotifyError::Io(e) => e,
+                mio::NotifyError::Full(..)
+                    => io::Error::new(io::ErrorKind::Other, "Mio notify error \
+                                                             (channel full)"),
+                mio::NotifyError::Closed(..)
+                    => io::Error::new(io::ErrorKind::Other, "Mio notify error \
+                                                             (channel closed)"),
+            },
+            CrustError::ChannelRecv(e)
+                => io::Error::new(io::ErrorKind::Other, e),
+            CrustError::ConfigFileHandler(e)
+                => io::Error::new(io::ErrorKind::Other, e),
+            CrustError::ServiceDiscNotEnabled
+                => io::Error::new(io::ErrorKind::Other, "Service discovery not \
+                                                         enabled"),
+            CrustError::ServiceDisc(e)
+                => io::Error::new(io::ErrorKind::Other, e),
+            CrustError::MioTimer(e)
+                => io::Error::new(io::ErrorKind::Other, format!("Mio timer \
+                                                                 error: {:?}",
+                                                                 e)),
+            CrustError::PayloadSizeProhibitive
+                => io::Error::new(io::ErrorKind::Other, "Payload size \
+                                                         prohibitive"),
+            CrustError::PeerNotFound(peer_id)
+                => io::Error::new(io::ErrorKind::Other, format!("Peer not \
+                                                                 found: {:?}",
+                                                                 peer_id)),
+            CrustError::Serialisation(e)
+                => io::Error::new(io::ErrorKind::Other, e),
+        }
+    }
+}
+

--- a/src/nat/punch_hole.rs
+++ b/src/nat/punch_hole.rs
@@ -118,6 +118,13 @@ impl<F> State for PunchHole<F>
              event_loop: &mut EventLoop<Core>,
              token: Token,
              event_set: EventSet) {
+        debug!("PunchHole ready: Listener == {:?}", self.listener_token);
+        for (i, (token, writing_stream)) in self.writing_streams.iter().enumerate() {
+            debug!("PunchHole ready: WritingStream[{}] {:?} ({} bytes)", i, token, writing_stream.bytes_written);
+        }
+        for (i, (token, reading_stream)) in self.reading_streams.iter().enumerate() {
+            debug!("PunchHole ready: ReadingStream[{}] {:?} ({} bytes)", i, token, reading_stream.bytes_read);
+        }
         debug!("PunchHole ready: {:?} {:?}", token, event_set);
 
         if token == self.listener_token {

--- a/src/nat/punch_hole.rs
+++ b/src/nat/punch_hole.rs
@@ -10,8 +10,8 @@ use std::cell::RefCell;
 use rand;
 use net2;
 use mio::tcp::{TcpStream, TcpListener};
-use mio::{PollOpt, EventSet, Token, EventLoop};
-use mio::{TryRead, TryWrite};
+use mio::{PollOpt, EventSet, Token, EventLoop, Timeout};
+use mio::{TryAccept, TryRead, TryWrite};
 use byteorder::{ReadBytesExt, BigEndian};
 
 use core::{Core, Context};
@@ -33,12 +33,14 @@ pub struct PunchHole<F> {
     their_secret: [u8; SECRET_LEN],
     best_stream: Option<(u64, TcpStream)>,
     finished: Option<F>,
+    timed_out: bool,
 }
 
 struct WritingStream {
     stream: TcpStream,
     nonce: [u8; NONCE_LEN],
     bytes_written: usize,
+    timeout: Timeout,
 }
 
 struct ReadingStream {
@@ -46,6 +48,7 @@ struct ReadingStream {
     nonce: [u8; NONCE_LEN],
     in_buff: [u8; SECRET_LEN + NONCE_LEN],
     bytes_read: usize,
+    //timeout: Timeout,
 }
 
 impl<F> PunchHole<F>
@@ -75,6 +78,13 @@ impl<F> PunchHole<F>
                                  token,
                                  EventSet::readable() | EventSet::error() | EventSet::hup(),
                                  PollOpt::level()));
+        match event_loop.timeout_ms(token, 5000) {
+            Ok(_) => (),
+            Err(e) => {
+                debug!("Error setting hole punch timeout: {:?}", e);
+                return Err(io::Error::new(io::ErrorKind::Other, "Error setting hole punch timeout"));
+            },
+        };
         let _ = core.insert_context(token, context);
 
         let mut streams = HashMap::new();
@@ -85,11 +95,19 @@ impl<F> PunchHole<F>
                                      token,
                                      EventSet::writable() | EventSet::error() | EventSet::hup(),
                                      PollOpt::level()));
+            let timeout = match event_loop.timeout_ms(token, 4000) {
+                Ok(timeout) => timeout,
+                Err(e) => {
+                    debug!("Error setting hole punch connect() timeout: {:?}", e);
+                    continue;
+                },
+            };
             let _ = core.insert_context(token, context);
             let writing_stream = WritingStream {
                 stream: stream,
                 nonce: rand::random(),
                 bytes_written: 0,
+                timeout: timeout,
             };
             let _ = streams.insert(token, writing_stream);
         }
@@ -104,20 +122,17 @@ impl<F> PunchHole<F>
             our_secret: our_priv_info.secret,
             their_secret: their_pub_info.secret,
             best_stream: None,
+            timed_out: false,
         };
         let _ = core.insert_state(context, Rc::new(RefCell::new(state)));
         Ok(())
     }
-}
 
-impl<F> State for PunchHole<F>
-    where F: FnOnce(&mut Core, &mut EventLoop<Core>, Option<TcpStream>) + Any
-{
-    fn ready(&mut self,
-             core: &mut Core,
-             event_loop: &mut EventLoop<Core>,
-             token: Token,
-             event_set: EventSet) {
+    fn handle_ready(&mut self,
+                    core: &mut Core,
+                    event_loop: &mut EventLoop<Core>,
+                    token: Token,
+                    event_set: EventSet) {
         debug!("PunchHole ready: Listener == {:?}", self.listener_token);
         for (i, (token, writing_stream)) in self.writing_streams.iter().enumerate() {
             debug!("PunchHole ready: WritingStream[{}] {:?} ({} bytes)", i, token, writing_stream.bytes_written);
@@ -143,12 +158,23 @@ impl<F> State for PunchHole<F>
                                               EventSet::hup(),
                                               PollOpt::level()) {
                         Ok(()) => (),
-                        Err(e) => debug!("Error reregistering stream: {}", e),
+                        Err(e) => {
+                            debug!("Error registering stream: {}", e);
+                            return;
+                        },
+                    };
+                    let timeout = match event_loop.timeout_ms(token, 4000) {
+                        Ok(timeout) => timeout,
+                        Err(e) => {
+                            debug!("Error registering timeout: {:?}", e);
+                            return;
+                        },
                     };
                     let writing_stream = WritingStream {
                         stream: stream,
                         nonce: rand::random(),
                         bytes_written: 0,
+                        timeout: timeout,
                     };
                     debug!("Accepted new incoming stream with {:?}", token);
                     let _ = core.insert_context(token, self.context);
@@ -162,20 +188,30 @@ impl<F> State for PunchHole<F>
             debug!("PunchHole writer ready");
             let res = {
                 let writing_stream = oe.get_mut();
-                let written = writing_stream.bytes_written;
-                if written < SECRET_LEN {
-                    match writing_stream.stream.try_write(&self.our_secret[written..]) {
-                        Ok(Some(n)) => {
-                            match writing_stream.stream.try_write(&writing_stream.nonce[..]) {
-                                Ok(Some(m)) => Ok(Some(n + m)),
-                                Ok(None) => Ok(Some(n)),
-                                Err(e) => Err(e),
+                let _ = event_loop.clear_timeout(writing_stream.timeout);
+                match event_loop.timeout_ms(token, 4000) {
+                    Ok(timeout) => {
+                        writing_stream.timeout = timeout;
+                        let written = writing_stream.bytes_written;
+                        if written < SECRET_LEN {
+                            match writing_stream.stream.try_write(&self.our_secret[written..]) {
+                                Ok(Some(n)) => {
+                                    match writing_stream.stream.try_write(&writing_stream.nonce[..]) {
+                                        Ok(Some(m)) => Ok(Some(n + m)),
+                                        Ok(None) => Ok(Some(n)),
+                                        Err(e) => Err(e),
+                                    }
+                                }
+                                x => x,
                             }
+                        } else {
+                            writing_stream.stream.try_write(&writing_stream.nonce[(written - SECRET_LEN)..])
                         }
-                        x => x,
-                    }
-                } else {
-                    writing_stream.stream.try_write(&writing_stream.nonce[(written - SECRET_LEN)..])
+                    },
+                    Err(e) => {
+                        debug!("Error setting timeout on writing stream: {:?}", e);
+                        Err(io::Error::new(io::ErrorKind::Other, "Error setting timeout on writing stream"))
+                    },
                 }
             };
             match res {
@@ -209,6 +245,7 @@ impl<F> State for PunchHole<F>
                     let written = oe.get_mut().bytes_written;
                     if written >= SECRET_LEN + NONCE_LEN {
                         let writing_stream = oe.remove();
+                        let _ = event_loop.clear_timeout(writing_stream.timeout);
                         match event_loop.reregister(&writing_stream.stream,
                                                     token,
                                                     EventSet::readable() | EventSet::error() |
@@ -235,7 +272,6 @@ impl<F> State for PunchHole<F>
             return;
         }
 
-        let mut done_read = false;
         if let hash_map::Entry::Occupied(mut oe) = self.reading_streams.entry(token) {
             debug!("PunchHole reader ready");
             let res = {
@@ -301,16 +337,54 @@ impl<F> State for PunchHole<F>
                             debug!("Highest scoring stream so far");
                             self.best_stream = Some((new_score, reading_stream.stream));
                         }
-                        done_read = true;
                     }
                 }
             }
         }
+    }
 
-        if self.writing_streams.is_empty() && self.reading_streams.is_empty() && done_read {
+    fn maybe_terminate(&mut self,
+                       core: &mut Core,
+                       event_loop: &mut EventLoop<Core>)
+    {
+        if self.writing_streams.is_empty() && self.reading_streams.is_empty() && 
+           (self.timed_out || self.best_stream.is_some())
+        {
             self.terminate(core, event_loop);
             return;
         }
+    }
+}
+
+impl<F> State for PunchHole<F>
+    where F: FnOnce(&mut Core, &mut EventLoop<Core>, Option<TcpStream>) + Any
+{
+    fn ready(&mut self,
+             core: &mut Core,
+             event_loop: &mut EventLoop<Core>,
+             token: Token,
+             event_set: EventSet) {
+        self.handle_ready(core, event_loop, token, event_set);
+        self.maybe_terminate(core, event_loop);
+    }
+
+    fn timeout(&mut self,
+               core: &mut Core,
+               event_loop: &mut EventLoop<Core>,
+               token: Token)
+    {
+        if token == self.listener_token {
+            debug!("Timed out waiting for more connections");
+            self.timed_out = true;
+        }
+
+        if let hash_map::Entry::Occupied(oe) = self.writing_streams.entry(token) {
+            debug!("Writing stream {:?} timed out.", token);
+            let _ = oe.remove();
+            let _ = core.remove_context(token);
+        }
+
+        self.maybe_terminate(core, event_loop);
     }
 
     fn terminate(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>) {

--- a/src/nat/punch_hole.rs
+++ b/src/nat/punch_hole.rs
@@ -31,7 +31,7 @@ pub struct PunchHole<F> {
     context: Context,
     our_secret: [u8; SECRET_LEN],
     their_secret: [u8; SECRET_LEN],
-    best_stream: Option<(u64, TcpStream)>,
+    best_stream: Option<(u64, TcpStream, Token)>,
     finished: Option<F>,
     timed_out: bool,
 }
@@ -52,7 +52,7 @@ struct ReadingStream {
 }
 
 impl<F> PunchHole<F>
-    where F: FnOnce(&mut Core, &mut EventLoop<Core>, Option<TcpStream>) + Any
+    where F: FnOnce(&mut Core, &mut EventLoop<Core>, Option<(TcpStream, Token)>) + Any
 {
     /// Start tcp hole punching
     pub fn start(core: &mut Core,
@@ -309,19 +309,19 @@ impl<F> PunchHole<F>
                     let read = oe.get_mut().bytes_read;
                     if read >= SECRET_LEN + NONCE_LEN {
                         let reading_stream = oe.remove();
-                        let _ = core.remove_context(token);
-                        match event_loop.deregister(&reading_stream.stream) {
-                            Ok(()) => (),
-                            Err(e) => {
-                                debug!("Error deregistering socket: {}", e);
-                                return;
-                            }
-                        };
                         let recv_secret = &reading_stream.in_buff[..SECRET_LEN];
                         if recv_secret != self.their_secret {
                             debug!("Secret mismatch during hole punching: {:?} != {:?}",
                                    recv_secret,
                                    self.their_secret);
+                            let _ = core.remove_context(token);
+                            match event_loop.deregister(&reading_stream.stream) {
+                                Ok(()) => (),
+                                Err(e) => {
+                                    debug!("Error deregistering socket: {}", e);
+                                    return;
+                                }
+                            };
                             return;
                         }
                         let recv_nonce = Cursor::new(&reading_stream.in_buff[SECRET_LEN..])
@@ -331,11 +331,11 @@ impl<F> PunchHole<F>
                             .read_u64::<BigEndian>()
                             .unwrap();
                         let new_score = recv_nonce.wrapping_add(sent_nonce);
-                        let old_score = self.best_stream.as_ref().map_or(0, |&(i, _)| i);
+                        let old_score = self.best_stream.as_ref().map_or(0, |&(i, _, _)| i);
                         debug!("Finshed reading. Stream score == {}, old score == {}", new_score, old_score);
                         if new_score >= old_score {
                             debug!("Highest scoring stream so far");
-                            self.best_stream = Some((new_score, reading_stream.stream));
+                            self.best_stream = Some((new_score, reading_stream.stream, token));
                         }
                     }
                 }
@@ -357,7 +357,7 @@ impl<F> PunchHole<F>
 }
 
 impl<F> State for PunchHole<F>
-    where F: FnOnce(&mut Core, &mut EventLoop<Core>, Option<TcpStream>) + Any
+    where F: FnOnce(&mut Core, &mut EventLoop<Core>, Option<(TcpStream, Token)>) + Any
 {
     fn ready(&mut self,
              core: &mut Core,
@@ -389,10 +389,8 @@ impl<F> State for PunchHole<F>
 
     fn terminate(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>) {
         debug!("PunchHole terminating");
-        let stream_opt = self.best_stream.take().map(|(_, s)| s);
+        let stream_opt = self.best_stream.take().map(|(_, s, token)| (s, token));
         let finished = self.finished.take().unwrap();
-
-        finished(core, event_loop, stream_opt);
 
         for (token, writing_stream) in &self.writing_streams {
             match event_loop.deregister(&writing_stream.stream) {
@@ -417,6 +415,8 @@ impl<F> State for PunchHole<F>
         let _ = core.remove_context(self.listener_token);
 
         let _ = core.remove_state(self.context);
+
+        finished(core, event_loop, stream_opt);
     }
 
     fn as_any(&mut self) -> &mut Any {

--- a/src/nat/punch_hole.rs
+++ b/src/nat/punch_hole.rs
@@ -133,14 +133,18 @@ impl<F> PunchHole<F>
                     event_loop: &mut EventLoop<Core>,
                     token: Token,
                     event_set: EventSet) {
-        debug!("PunchHole ready: Listener == {:?}", self.listener_token);
+        let us = Cursor::new(&self.our_secret[..])
+            .read_u32::<BigEndian>()
+            .unwrap();
+
+        debug!("{:0x} PunchHole ready: Listener == {:?}", us, self.listener_token);
         for (i, (token, writing_stream)) in self.writing_streams.iter().enumerate() {
-            debug!("PunchHole ready: WritingStream[{}] {:?} ({} bytes)", i, token, writing_stream.bytes_written);
+            debug!("{:0x} PunchHole ready: WritingStream[{}] {:?} ({} bytes)", us, i, token, writing_stream.bytes_written);
         }
         for (i, (token, reading_stream)) in self.reading_streams.iter().enumerate() {
-            debug!("PunchHole ready: ReadingStream[{}] {:?} ({} bytes)", i, token, reading_stream.bytes_read);
+            debug!("{:0x} PunchHole ready: ReadingStream[{}] {:?} ({} bytes)", us, i, token, reading_stream.bytes_read);
         }
-        debug!("PunchHole ready: {:?} {:?}", token, event_set);
+        debug!("{:0x} PunchHole ready: {:?} {:?}", us, token, event_set);
 
         if token == self.listener_token {
             debug!("PunchHole listener ready");

--- a/src/service.rs
+++ b/src/service.rs
@@ -508,7 +508,7 @@ mod tests {
     #[test]
     fn rendezvous_connect_two_peers() {
         maidsafe_utilities::log::init(true).unwrap();
-        timebomb(Duration::from_secs(5), || {
+        timebomb(Duration::from_secs(10), || {
             let (event_tx_0, event_rx_0) = get_event_sender();
             let service_0 = unwrap_result!(Service::new(event_tx_0));
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -324,9 +324,8 @@ impl Service {
                 {
                     debug!("PunchHole finished");
                     match stream_opt {
-                        Some(stream) => {
+                        Some((stream, token)) => {
                             debug!("PunchHole succeeded. Creating ActiveConnection");
-                            let token = core.get_new_token();
                             let socket = Socket::wrap(stream);
                             let event_tx = (&*event_tx_rc).clone();
 
@@ -480,6 +479,7 @@ mod tests {
     // use maidsafe_utilities::log;
     use std::sync::mpsc::Receiver;
     use std::time::Duration;
+    use maidsafe_utilities;
 
     use event::Event;
     use service::Service;
@@ -506,8 +506,8 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn rendezvous_connect_two_peers() {
+        maidsafe_utilities::log::init(true).unwrap();
         timebomb(Duration::from_secs(5), || {
             let (event_tx_0, event_rx_0) = get_event_sender();
             let service_0 = unwrap_result!(Service::new(event_tx_0));

--- a/src/service.rs
+++ b/src/service.rs
@@ -322,8 +322,10 @@ impl Service {
                                          their_connection_info.tcp_info,
                                          move |core, event_loop, stream_opt|
                 {
+                    debug!("PunchHole finished");
                     match stream_opt {
                         Some(stream) => {
+                            debug!("PunchHole succeeded. Creating ActiveConnection");
                             let token = core.get_new_token();
                             let socket = Socket::wrap(stream);
                             let event_tx = (&*event_tx_rc).clone();

--- a/src/service_discovery/errors.rs
+++ b/src/service_discovery/errors.rs
@@ -19,27 +19,24 @@ use std::io;
 use std::net::AddrParseError;
 use maidsafe_utilities::serialisation::SerialisationError;
 
-#[derive(Debug)]
-pub enum ServiceDiscoveryError {
-    Io(io::Error),
-    AddrParse(AddrParseError),
-    Serialisation(SerialisationError),
-}
-
-impl From<io::Error> for ServiceDiscoveryError {
-    fn from(e: io::Error) -> Self {
-        ServiceDiscoveryError::Io(e)
+quick_error! {
+    #[derive(Debug)]
+    pub enum ServiceDiscoveryError {
+        Io(e: io::Error) {
+            description("Io error during service discovery")
+            display("Io error during service discovery: {}", e)
+            from()
+        }
+        AddrParse(e: AddrParseError) {
+            description("Error parsing address for service discovery")
+            display("Error parsing address for service discovery: {}", e)
+            from()
+        }
+        Serialisation(e: SerialisationError) {
+            description("Serialisation error during service discovery")
+            display("Serialisation error during service discovery: {}", e)
+            from()
+        }
     }
 }
 
-impl From<AddrParseError> for ServiceDiscoveryError {
-    fn from(e: AddrParseError) -> Self {
-        ServiceDiscoveryError::AddrParse(e)
-    }
-}
-
-impl From<SerialisationError> for ServiceDiscoveryError {
-    fn from(e: SerialisationError) -> Self {
-        ServiceDiscoveryError::Serialisation(e)
-    }
-}


### PR DESCRIPTION
Make `CrustError` convert to `io::Error` without panicking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/742)
<!-- Reviewable:end -->
