### PR TITLE
fix/event: fix new-peer-error edge case - important commit

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -390,8 +390,8 @@ impl Service {
 
     /// Disconnect from the given peer and returns whether there was a connection at all.
     pub fn disconnect(&self, peer_id: PeerId) -> bool {
-        let context = match self.cm.lock().unwrap().remove(&peer_id) {
-            Some(ConnectionId { active_connection: Some(context), .. }) => context,
+        let context = match self.cm.lock().unwrap().get(&peer_id) {
+            Some(&ConnectionId { active_connection: Some(context), .. }) => context,
             _ => return false,
         };
 


### PR DESCRIPTION
This is an interesting commit. So basically each time routing ci test was run with large number of nodes (e.g. 50) we use to see some occasional NewPeer(Err) which should be virtually impossible to get after the previous fix at-least on the same computer (localhost). It turns out the the backlog value of TCP Listener was set to 1. What this does is silently ignore incoming TCP 3-way handshake if there is one pending handshake already in the kernel's backlog. So although our code is resilient to spurious NewPeer(Err) the kernel never informs about an incoming SYN and thus we get a few NewPeer(Err) for no apparant reason. This commit puts that to 100 currently. Now with this the system is slow so there is a call to accept in a loop till we get a spurious accept at which we go back to event loop and this compensates for the slowness (balances out). 100 is chosen because https://www.ibm.com/support/knowledgecenter/SSFKSJ_9.0.0/com.ibm.mq.con.doc/q016110_.htm

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/747)

<!-- Reviewable:end -->
