### PR TITLE
feat/priority: implement message prioritization

### DIFF
--- a/src/connect/connection_candidate.rs
+++ b/src/connect/connection_candidate.rs
@@ -21,7 +21,7 @@ use std::rc::Rc;
 
 use active_connection::ActiveConnection;
 use service::{ConnectionId, ConnectionMap};
-use core::{Core, State};
+use core::{Core, State, Priority};
 use event::Event;
 use message::Message;
 use mio::{EventLoop, EventSet, Token};
@@ -60,7 +60,7 @@ impl ConnectionCandidate {
         let _ = core.insert_state(context, state.clone());
 
         if our_id > their_id {
-            state.borrow_mut().write(core, event_loop, Some(Message::ChooseConnection));
+            state.borrow_mut().write(core, event_loop, Some((Message::ChooseConnection, 0)));
         }
     }
 
@@ -79,7 +79,10 @@ impl ConnectionCandidate {
         }
     }
 
-    fn write(&mut self, core: &mut Core, event_loop: &mut EventLoop<Core>, msg: Option<Message>) {
+    fn write(&mut self,
+             core: &mut Core,
+             event_loop: &mut EventLoop<Core>,
+             msg: Option<(Message, Priority)>) {
         let terminate = match self.cm.lock().unwrap().get(&self.their_id) {
             Some(&ConnectionId { active_connection: Some(_), .. }) => true,
             _ => false,

--- a/src/connect/establish_direct_connection.rs
+++ b/src/connect/establish_direct_connection.rs
@@ -86,7 +86,7 @@ impl<F> EstablishDirectConnection<F>
             None
         } else {
             self.sent = true;
-            Some(Message::Connect(self.our_public_key, self.name_hash))
+            Some((Message::Connect(self.our_public_key, self.name_hash), 0))
         };
 
         match self.socket
@@ -203,4 +203,3 @@ impl<F> State for EstablishDirectConnection<F>
         self
     }
 }
-

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -21,7 +21,9 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+pub use self::state::Priority;
 pub use self::state::State;
+
 /// State Trait
 pub mod state;
 

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -21,6 +21,11 @@ use std::any::Any;
 use core::Core;
 use mio::{EventLoop, EventSet, Handler, Token};
 
+/// Priority of a message to be sent by Crust. Priority 0 being the highest and very unlikely to be
+/// dropped. Priority 255 is hence the least important and will be preempted/dropped if need be to
+/// allow higher priority messages through.
+pub type Priority = u8;
+
 /// A trait for state machines
 pub trait State {
     /// Return the state as an `Any`
@@ -45,5 +50,10 @@ pub trait State {
     }
 
     /// Write some data
-    fn write(&mut self, _core: &mut Core, _event_loop: &mut EventLoop<Core>, _data: Vec<u8>) {}
+    fn write(&mut self,
+             _core: &mut Core,
+             _event_loop: &mut EventLoop<Core>,
+             _data: Vec<u8>,
+             _priority: Priority) {
+    }
 }

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -21,7 +21,7 @@ use std::any::Any;
 use core::Core;
 use mio::{EventLoop, EventSet, Handler, Token};
 
-/// Priority of a message to be sent by Crust. Priority 0 being the highest and very unlikely to be
+/// Priority of a message to be sent by Crust. Priority 0 being the highest and will _not_ be
 /// dropped. Priority 255 is hence the least important and will be preempted/dropped if need be to
 /// allow higher priority messages through.
 pub type Priority = u8;

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -147,7 +147,8 @@ impl Socket {
             data.set_position(0);
             try!(data.write_u32::<LittleEndian>(len as u32));
 
-            let entry = self.write_queue.entry(priority).or_insert(VecDeque::with_capacity(10));
+            let entry =
+                self.write_queue.entry(priority).or_insert_with(|| VecDeque::with_capacity(10));
             entry.push_back(data.into_inner());
         }
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -300,7 +300,8 @@ mod broken_peer {
                         let public_key = box_::gen_keypair().0;
                         unwrap_result!(self.0.write(event_loop,
                                                     token,
-                                                    Some(Message::BootstrapResponse(public_key))));
+                                                    Some((Message::BootstrapResponse(public_key),
+                                                          0))));
                     }
                     Some(_) | None => (),
                 }


### PR DESCRIPTION
All messages to be sent out now need to specify priority. Crust will do it best to ensure the higher priority (0 being the highest) messages are sent before any lower priority ones even if lower priority were the ones to come into the queue first. Priority ranges between 0 (highest) and 255 (lowest).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/754)
<!-- Reviewable:end -->
