### PR TITLE
feat/service-disc: revert flipping of service disc

### DIFF
--- a/src/main/bootstrap/mod.rs
+++ b/src/main/bootstrap/mod.rs
@@ -199,15 +199,8 @@ impl State for Bootstrap {
 
         let rx = self.sd_meta.take().expect("Logic Error").rx;
 
-        if cfg!(test) {
-            while let Ok(listeners) = rx.try_recv() {
-                self.peers.extend(listeners);
-            }
-        } else if rx.try_recv().is_ok() {
-            error!("Another instance of Crust is already running on this LAN. Only one is \
-                    allowed in this version of Crust.");
-            let _ = self.event_tx.send(Event::BootstrapFailed);
-            return self.terminate(core, el);
+        while let Ok(listeners) = rx.try_recv() {
+            self.peers.extend(listeners);
         }
 
         self.begin_bootstrap(core, el);


### PR DESCRIPTION
Revert the condition which disallowed crust to bootstrap if it finds other instances running on LAN. Instead expose functionality for upper layers to determine the usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/crust/785)
<!-- Reviewable:end -->
