### PR TITLE
fix/config: Expose `Config` structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,32 @@
 env:
   global:
-    - secure: SkbGQw5IEClmE2l6skYTFbWuXBn7LcX23cV6uwmDK5Ah0vJ+vXGN5AIV9hhPaMIytwIp4HsWOf7LKHlWlc3+ot0qFVDMRFHamg1f8zWEwbvSA8ozSGVjlcXihrWQ/y5DjBefd9kNdrXb7kq0NA/Pqy/loO91m1e7SggujOC1F2M=
+    - RUST_BACKTRACE=1
+    - PATH=$PATH:$HOME/.cargo/bin
 os:
   - linux
   - osx
 language: rust
 rust:
-# - beta
   - stable
   - nightly
-matrix:
-  allow_failures:
-    - rust: nightly
 sudo: false
 branches:
   only:
     - master
 cache:
   cargo: true
-  directories:
-    - $HOME/elfutils
+before_script:
+  - (which cargo-install-update && cargo install-update cargo-update) || cargo install cargo-update
+  - (which rustfmt && cargo install-update rustfmt) || cargo install rustfmt
+  - (which cargo-prune && cargo install-update cargo-prune) || cargo install cargo-prune
 script:
-  - curl -sSL https://github.com/maidsafe/QA/raw/master/Bash%20Scripts/Travis/build_and_run_tests.sh | bash
+  - if [ "${TRAVIS_RUST_VERSION}" = stable ]; then
+        (
+            set -x;
+            cargo fmt -- --write-mode=diff &&
+            cargo test --verbose --release
+        );
+    fi
+  - curl -sSL https://github.com/maidsafe/QA/raw/master/bash_scripts/travis/run_clippy.sh | bash
 before_cache:
-  - curl -sSLO https://github.com/maidsafe/QA/raw/master/Bash%20Scripts/Travis/install_elfutils.sh
-  - . install_elfutils.sh
-after_success:
-  - curl -sSL https://github.com/maidsafe/QA/raw/master/Bash%20Scripts/Travis/after_success.sh | bash
+  - cargo prune

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["MaidSafe Developers <dev@maidsafe.net>"]
 description = "Peer-to-peer networking library. Automatically reconnect and manage connections."
-documentation = "http://docs.maidsafe.net/crust/latest"
+documentation = "https://docs.rs/crust/"
 homepage = "http://maidsafe.net"
 license = "GPL-3.0"
 name = "crust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.19.0"
 [dependencies]
 byteorder = "~0.5.3"
 c_linked_list = "~1.1.0"
-clippy = {version = "~0.0.94", optional = true}
+clippy = {version = "=0.0.99", optional = true}
 config_file_handler = "~0.4.0"
 crossbeam = "~0.2.10"
 igd = "~0.5.1"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Reliable p2p network connections in Rust with NAT traversal. One of the most nee
 |:---:|:--------:|:---------:|:-----:|:------:|:----:|
 |[![](http://meritbadge.herokuapp.com/crust)](https://crates.io/crates/crust)|[![Build Status](https://travis-ci.org/maidsafe/crust.svg?branch=master)](https://travis-ci.org/maidsafe/crust)|[![Build Status](http://ci.maidsafe.net:8080/buildStatus/icon?job=crust_arm_status_badge)](http://ci.maidsafe.net:8080/job/crust_arm_status_badge/)|[![Build status](https://ci.appveyor.com/api/projects/status/ajw6ab26p86jdac4/branch/master?svg=true)](https://ci.appveyor.com/project/MaidSafe-QA/crust/branch/master)|[![Coverage Status](https://coveralls.io/repos/maidsafe/crust/badge.svg)](https://coveralls.io/r/maidsafe/crust)|[![Stories in Ready](https://badge.waffle.io/maidsafe/crust.png?label=ready&title=Ready)](https://waffle.io/maidsafe/crust)|
 
-| [API Documentation - master branch](http://docs.maidsafe.net/crust/master) | [MaidSafe website](http://maidsafe.net) | [SAFE Network Forum](https://forum.safenetwork.io) |
+| [![Documentation](https://docs.rs/crust/badge.svg)](https://docs.rs/crust) | [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
 |:------:|:-------:|:-------:|:-------:|
 
 ## Overview

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,14 +7,12 @@ branches:
   only:
     - master
 
-clone_depth: 50
+clone_depth: 1
 
 install:
   - ps: |
         $url = "https://github.com/maidsafe/QA/raw/master/Powershell%20Scripts/AppVeyor"
         cmd /c curl -fsSL -o "Install Rustup.ps1" "$url/Install%20Rustup.ps1"
-        cmd /c curl -fsSL -o "Build.ps1" "$url/Build.ps1"
-        cmd /c curl -fsSL -o "Run Tests.ps1" "$url/Run%20Tests.ps1"
         . ".\Install Rustup.ps1"
 
 platform:
@@ -22,11 +20,10 @@ platform:
   - x64
 
 configuration:
-#  - Debug
   - Release
 
 build_script:
-  - ps: . ".\Build.ps1"
+  - cargo rustc --verbose --release -- --test -Zno-trans
 
 test_script:
-  - ps: . ".\Run Tests.ps1"
+  - cargo test --verbose --release

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,3 @@
 reorder_imports = true
+reorder_imported_names = true
+use_try_shorthand = true

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -16,6 +16,8 @@
 // relating to use of the SAFE Network Software.
 // Defines `Core`, the mio handler and the core of the event loop.
 
+use rust_sodium::crypto::hash::sha256;
+
 pub use self::core::{Core, CoreMessage, CoreTimerId};
 pub use self::error::CommonError;
 pub use self::message::Message;
@@ -23,7 +25,7 @@ pub use self::socket::Socket;
 pub use self::socket_addr::{SocketAddr, IpAddr};
 pub use self::state::State;
 
-pub type NameHash = u64;
+pub type NameHash = [u8; sha256::DIGESTBYTES];
 /// Priority of a message to be sent by Crust. A lower value means a higher priority, so Priority 0
 /// is the highest one. Low-priority messages will be preempted if need be to allow higher priority
 /// messages through. Messages with a value `>= MSG_DROP_PRIORITY` will even be dropped, if

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -22,7 +22,7 @@ pub use self::core::{Core, CoreMessage, CoreTimerId};
 pub use self::error::CommonError;
 pub use self::message::Message;
 pub use self::socket::Socket;
-pub use self::socket_addr::{SocketAddr, IpAddr};
+pub use self::socket_addr::{IpAddr, SocketAddr};
 pub use self::state::State;
 
 pub type NameHash = [u8; sha256::DIGESTBYTES];

--- a/src/common/socket.rs
+++ b/src/common/socket.rs
@@ -37,7 +37,7 @@ pub struct Socket {
 
 impl Socket {
     pub fn connect(addr: &SocketAddr) -> Result<Self> {
-        let stream = try!(TcpStream::connect(addr));
+        let stream = TcpStream::connect(addr)?;
         Ok(Self::wrap(stream))
     }
 
@@ -54,8 +54,8 @@ impl Socket {
     }
 
     pub fn peer_addr(&self) -> Result<SocketAddr> {
-        let inner = try!(self.inner.as_ref().ok_or(CommonError::UninitialisedSocket));
-        Ok(try!(inner.stream.peer_addr()))
+        let inner = self.inner.as_ref().ok_or(CommonError::UninitialisedSocket)?;
+        Ok(inner.stream.peer_addr()?)
     }
 
     // Read message from the socket. Call this from inside the `ready` handler.
@@ -66,7 +66,7 @@ impl Socket {
     //                     again in the next invocation of the `ready` handler.
     //   - Err(error):     there was an error reading from the socket.
     pub fn read<T: Decodable>(&mut self) -> Result<Option<T>> {
-        let inner = try!(self.inner.as_mut().ok_or(CommonError::UninitialisedSocket));
+        let inner = self.inner.as_mut().ok_or(CommonError::UninitialisedSocket)?;
         inner.read()
     }
 
@@ -82,7 +82,7 @@ impl Socket {
                                token: Token,
                                msg: Option<(T, Priority)>)
                                -> ::Res<bool> {
-        let inner = try!(self.inner.as_mut().ok_or(CommonError::UninitialisedSocket));
+        let inner = self.inner.as_mut().ok_or(CommonError::UninitialisedSocket)?;
         inner.write(el, token, msg)
     }
 }
@@ -100,9 +100,9 @@ impl Evented for Socket {
                 interest: EventSet,
                 opts: PollOpt)
                 -> io::Result<()> {
-        let inner = try!(self.inner
+        let inner = self.inner
             .as_ref()
-            .ok_or(io::Error::new(ErrorKind::Other, CommonError::UninitialisedSocket)));
+            .ok_or(io::Error::new(ErrorKind::Other, CommonError::UninitialisedSocket))?;
         inner.register(selector, token, interest, opts)
     }
 
@@ -112,16 +112,16 @@ impl Evented for Socket {
                   interest: EventSet,
                   opts: PollOpt)
                   -> io::Result<()> {
-        let inner = try!(self.inner
+        let inner = self.inner
             .as_ref()
-            .ok_or(io::Error::new(ErrorKind::Other, CommonError::UninitialisedSocket)));
+            .ok_or(io::Error::new(ErrorKind::Other, CommonError::UninitialisedSocket))?;
         inner.reregister(selector, token, interest, opts)
     }
 
     fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
-        let inner = try!(self.inner
+        let inner = self.inner
             .as_ref()
-            .ok_or(io::Error::new(ErrorKind::Other, CommonError::UninitialisedSocket)));
+            .ok_or(io::Error::new(ErrorKind::Other, CommonError::UninitialisedSocket))?;
         inner.deregister(selector)
     }
 }
@@ -143,7 +143,7 @@ impl SockInner {
     //                     again in the next invocation of the `ready` handler.
     //   - Err(error):     there was an error reading from the socket.
     fn read<T: Decodable>(&mut self) -> Result<Option<T>> {
-        if let Some(message) = try!(self.read_from_buffer()) {
+        if let Some(message) = self.read_from_buffer()? {
             return Ok(Some(message));
         }
 
@@ -174,8 +174,7 @@ impl SockInner {
                 return Ok(None);
             }
 
-            self.read_len = try!(Cursor::new(&self.read_buffer)
-                .read_u32::<LittleEndian>()) as usize;
+            self.read_len = Cursor::new(&self.read_buffer).read_u32::<LittleEndian>()? as usize;
 
             if self.read_len > MAX_PAYLOAD_SIZE {
                 return Err(CommonError::PayloadSizeProhibitive);
@@ -188,7 +187,7 @@ impl SockInner {
             return Ok(None);
         }
 
-        let result = try!(deserialise_from(&mut Cursor::new(&self.read_buffer)));
+        let result = deserialise_from(&mut Cursor::new(&self.read_buffer))?;
 
         self.read_buffer = self.read_buffer[self.read_len..].to_owned();
         self.read_len = 0;
@@ -233,11 +232,11 @@ impl SockInner {
 
             let _ = data.write_u32::<LittleEndian>(0);
 
-            try!(serialise_into(&msg, &mut data));
+            serialise_into(&msg, &mut data)?;
 
             let len = data.position() - mem::size_of::<u32>() as u64;
             data.set_position(0);
-            try!(data.write_u32::<LittleEndian>(len as u32));
+            data.write_u32::<LittleEndian>(len as u32)?;
 
             let entry =
                 self.write_queue.entry(priority).or_insert_with(|| VecDeque::with_capacity(10));
@@ -281,7 +280,7 @@ impl SockInner {
             EventSet::error() | EventSet::hup() | EventSet::readable() | EventSet::writable()
         };
 
-        try!(el.reregister(self, token, event_set, PollOpt::edge()));
+        el.reregister(self, token, event_set, PollOpt::edge())?;
 
         Ok(done)
     }

--- a/src/common/socket.rs
+++ b/src/common/socket.rs
@@ -102,7 +102,7 @@ impl Evented for Socket {
                 -> io::Result<()> {
         let inner = self.inner
             .as_ref()
-            .ok_or(io::Error::new(ErrorKind::Other, CommonError::UninitialisedSocket))?;
+            .ok_or_else(|| io::Error::new(ErrorKind::Other, CommonError::UninitialisedSocket))?;
         inner.register(selector, token, interest, opts)
     }
 
@@ -114,14 +114,14 @@ impl Evented for Socket {
                   -> io::Result<()> {
         let inner = self.inner
             .as_ref()
-            .ok_or(io::Error::new(ErrorKind::Other, CommonError::UninitialisedSocket))?;
+            .ok_or_else(|| io::Error::new(ErrorKind::Other, CommonError::UninitialisedSocket))?;
         inner.reregister(selector, token, interest, opts)
     }
 
     fn deregister(&self, selector: &mut Selector) -> io::Result<()> {
         let inner = self.inner
             .as_ref()
-            .ok_or(io::Error::new(ErrorKind::Other, CommonError::UninitialisedSocket))?;
+            .ok_or_else(|| io::Error::new(ErrorKind::Other, CommonError::UninitialisedSocket))?;
         inner.deregister(selector)
     }
 }

--- a/src/common/socket_addr.rs
+++ b/src/common/socket_addr.rs
@@ -33,7 +33,7 @@ impl Encodable for SocketAddr {
 
 impl Decodable for SocketAddr {
     fn decode<D: Decoder>(d: &mut D) -> Result<SocketAddr, D::Error> {
-        let as_string = try!(d.read_str());
+        let as_string = d.read_str()?;
         match net::SocketAddr::from_str(&as_string[..]) {
             Ok(sa) => Ok(SocketAddr(sa)),
             Err(e) => {
@@ -72,7 +72,7 @@ impl Encodable for SocketAddrV4 {
 
 impl Decodable for SocketAddrV4 {
     fn decode<D: Decoder>(d: &mut D) -> Result<SocketAddrV4, D::Error> {
-        let as_string = try!(d.read_str());
+        let as_string = d.read_str()?;
         match net::SocketAddrV4::from_str(&as_string[..]) {
             Ok(sa) => Ok(SocketAddrV4(sa)),
             Err(e) => {
@@ -104,7 +104,7 @@ impl Encodable for SocketAddrV6 {
 
 impl Decodable for SocketAddrV6 {
     fn decode<D: Decoder>(d: &mut D) -> Result<SocketAddrV6, D::Error> {
-        let as_string = try!(d.read_str());
+        let as_string = d.read_str()?;
         match net::SocketAddrV6::from_str(&as_string[..]) {
             Ok(sa) => Ok(SocketAddrV6(sa)),
             Err(e) => {
@@ -156,7 +156,7 @@ impl Encodable for IpAddr {
 
 impl Decodable for IpAddr {
     fn decode<D: Decoder>(d: &mut D) -> Result<IpAddr, D::Error> {
-        let as_string = try!(d.read_str());
+        let as_string = d.read_str()?;
         match net::IpAddr::from_str(&as_string[..]) {
             Ok(ia) => Ok(IpAddr(ia)),
             Err(e) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 #![doc(html_logo_url =
            "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",
        html_favicon_url = "http://maidsafe.net/img/favicon.ico",
-       html_root_url = "http://maidsafe.github.io/crust/")]
+       html_root_url = "https://docs.rs/crust")]
 
 // For explanation of lint checks, run `rustc -W help` or see
 // https://github.com/maidsafe/QA/blob/master/Documentation/Rust%20Lint%20Checks.md

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ mod service_discovery;
 mod nat;
 
 pub use common::{MSG_DROP_PRIORITY, Priority};
-pub use main::{ConnectionInfoResult, CrustError, Event, PeerId, PrivConnectionInfo,
+pub use main::{ConnectionInfoResult, Config, CrustError, Event, PeerId, PrivConnectionInfo,
                PubConnectionInfo, Service};
 
 /// Used to receive events from a `Service`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ mod service_discovery;
 mod nat;
 
 pub use common::{MSG_DROP_PRIORITY, Priority};
-pub use main::{ConnectionInfoResult, Config, CrustError, Event, PeerId, PrivConnectionInfo,
+pub use main::{Config, ConnectionInfoResult, CrustError, Event, PeerId, PrivConnectionInfo,
                PubConnectionInfo, Service};
 
 /// Used to receive events from a `Service`.

--- a/src/main/active_connection.rs
+++ b/src/main/active_connection.rs
@@ -226,10 +226,10 @@ struct Heartbeat {
 impl Heartbeat {
     fn new(el: &mut EventLoop<Core>, state_id: Token) -> ::Res<Self> {
         let recv_timer = CoreTimerId::new(state_id, 0);
-        let recv_timeout = try!(el.timeout_ms(recv_timer, INACTIVITY_TIMEOUT_MS));
+        let recv_timeout = el.timeout_ms(recv_timer, INACTIVITY_TIMEOUT_MS)?;
 
         let send_timer = CoreTimerId::new(state_id, 1);
-        let send_timeout = try!(el.timeout_ms(send_timer, HEARTBEAT_PERIOD_MS));
+        let send_timeout = el.timeout_ms(send_timer, HEARTBEAT_PERIOD_MS)?;
 
         Ok(Heartbeat {
             recv_timeout: recv_timeout,
@@ -252,13 +252,13 @@ impl Heartbeat {
 
     fn reset_receive(&mut self, el: &mut EventLoop<Core>) -> ::Res<()> {
         let _ = el.clear_timeout(self.recv_timeout);
-        self.recv_timeout = try!(el.timeout_ms(self.recv_timer, INACTIVITY_TIMEOUT_MS));
+        self.recv_timeout = el.timeout_ms(self.recv_timer, INACTIVITY_TIMEOUT_MS)?;
         Ok(())
     }
 
     fn reset_send(&mut self, el: &mut EventLoop<Core>) -> ::Res<()> {
         let _ = el.clear_timeout(self.send_timeout);
-        self.send_timeout = try!(el.timeout_ms(self.send_timer, HEARTBEAT_PERIOD_MS));
+        self.send_timeout = el.timeout_ms(self.send_timer, HEARTBEAT_PERIOD_MS)?;
         Ok(())
     }
 

--- a/src/main/bootstrap/cache.rs
+++ b/src/main/bootstrap/cache.rs
@@ -29,7 +29,7 @@ pub struct Cache {
 
 impl Cache {
     pub fn _cleanup() -> ::Res<()> {
-        try!(config_file_handler::cleanup(&try!(Self::get_default_file_name())));
+        config_file_handler::cleanup(&Self::get_default_file_name()?)?;
         Ok(())
     }
 
@@ -37,7 +37,7 @@ impl Cache {
         let name = if let Some(name) = name.clone() {
             OsString::from(name)
         } else {
-            try!(Self::get_default_file_name())
+            Self::get_default_file_name()?
         };
 
         Ok(Cache {
@@ -46,7 +46,7 @@ impl Cache {
     }
 
     pub fn get_default_file_name() -> ::Res<OsString> {
-        let mut name = try!(config_file_handler::exe_file_stem());
+        let mut name = config_file_handler::exe_file_stem()?;
         name.push(".bootstrap.cache");
         Ok(name)
     }

--- a/src/main/bootstrap/mod.rs
+++ b/src/main/bootstrap/mod.rs
@@ -18,7 +18,7 @@
 mod cache;
 mod try_peer;
 
-use common::{self, Core, CoreTimerId, Socket, State};
+use common::{self, Core, CoreTimerId, NameHash, Socket, State};
 
 use main::{ActiveConnection, Config, ConnectionMap, CrustError, Event, PeerId};
 use mio::{EventLoop, Timeout, Token};
@@ -46,7 +46,7 @@ pub struct Bootstrap {
     cm: ConnectionMap,
     peers: Vec<common::SocketAddr>,
     blacklist: HashSet<net::SocketAddr>,
-    name_hash: u64,
+    name_hash: NameHash,
     our_pk: PublicKey,
     event_tx: ::CrustEventSender,
     sd_meta: Option<ServiceDiscMeta>,
@@ -60,7 +60,7 @@ pub struct Bootstrap {
 impl Bootstrap {
     pub fn start(core: &mut Core,
                  el: &mut EventLoop<Core>,
-                 name_hash: u64,
+                 name_hash: NameHash,
                  our_pk: PublicKey,
                  cm: ConnectionMap,
                  config: &Config,

--- a/src/main/bootstrap/mod.rs
+++ b/src/main/bootstrap/mod.rs
@@ -71,12 +71,12 @@ impl Bootstrap {
                  -> ::Res<()> {
         let mut peers = Vec::with_capacity(MAX_CONTACTS_EXPECTED);
 
-        let mut cache = try!(Cache::new(&config.bootstrap_cache_name));
+        let mut cache = Cache::new(&config.bootstrap_cache_name)?;
         peers.extend(cache.read_file());
         peers.extend(config.hard_coded_contacts.clone());
 
         let bs_timer = CoreTimerId::new(token, BOOTSTRAP_TIMER_ID);
-        let bs_timeout = try!(el.timeout_ms(bs_timer, BOOTSTRAP_TIMEOUT_MS));
+        let bs_timeout = el.timeout_ms(bs_timer, BOOTSTRAP_TIMEOUT_MS)?;
         let sd_meta = match seek_peers(core, el, service_discovery_token, token) {
             Ok((rx, timeout)) => {
                 Some(ServiceDiscMeta {
@@ -239,9 +239,9 @@ fn seek_peers(core: &mut Core,
 
         let (obs, rx) = mpsc::channel();
         state.register_observer(obs);
-        try!(state.seek_peers());
-        let timeout = try!(el.timeout_ms(CoreTimerId::new(token, SERVICE_DISCOVERY_TIMER_ID),
-                                         SERVICE_DISCOVERY_TIMEOUT_MS));
+        state.seek_peers()?;
+        let timeout = el.timeout_ms(CoreTimerId::new(token, SERVICE_DISCOVERY_TIMER_ID),
+                        SERVICE_DISCOVERY_TIMEOUT_MS)?;
 
         Ok((rx, timeout))
     } else {

--- a/src/main/bootstrap/try_peer.rs
+++ b/src/main/bootstrap/try_peer.rs
@@ -50,13 +50,13 @@ impl TryPeer {
                  name_hash: NameHash,
                  finish: Finish)
                  -> ::Res<Token> {
-        let socket = try!(Socket::connect(&peer));
+        let socket = Socket::connect(&peer)?;
         let token = core.get_new_token();
 
-        try!(el.register(&socket,
-                         token,
-                         EventSet::error() | EventSet::hup() | EventSet::writable(),
-                         PollOpt::edge()));
+        el.register(&socket,
+                      token,
+                      EventSet::error() | EventSet::hup() | EventSet::writable(),
+                      PollOpt::edge())?;
 
         let state = TryPeer {
             token: token,

--- a/src/main/bootstrap/try_peer.rs
+++ b/src/main/bootstrap/try_peer.rs
@@ -16,7 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 
-use common::{Core, Message, Priority, Socket, State};
+use common::{Core, Message, NameHash, Priority, Socket, State};
 use main::PeerId;
 use mio::{EventLoop, EventSet, PollOpt, Token};
 use rust_sodium::crypto::box_::PublicKey;
@@ -47,7 +47,7 @@ impl TryPeer {
                  el: &mut EventLoop<Core>,
                  peer: SocketAddr,
                  our_pk: PublicKey,
-                 name_hash: u64,
+                 name_hash: NameHash,
                  finish: Finish)
                  -> ::Res<Token> {
         let socket = try!(Socket::connect(&peer));

--- a/src/main/config_handler.rs
+++ b/src/main/config_handler.rs
@@ -16,7 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 
-use common::{SocketAddr, IpAddr};
+use common::{IpAddr, SocketAddr};
 use config_file_handler::{self, FileHandler};
 use std::collections::HashSet;
 use std::ffi::OsString;
@@ -57,8 +57,8 @@ impl Default for Config {
 
 /// Reads the default crust config file.
 pub fn read_config_file() -> ::Res<Config> {
-    let file_handler = try!(FileHandler::new(&try!(get_file_name()), false));
-    let cfg = try!(file_handler.read_file());
+    let file_handler = FileHandler::new(&get_file_name()?, false)?;
+    let cfg = file_handler.read_file()?;
     Ok(cfg)
 }
 
@@ -79,18 +79,18 @@ pub fn write_config_file(hard_coded_contacts: Option<Vec<SocketAddr>>) -> ::Res<
         config.hard_coded_contacts = contacts;
     }
 
-    let mut config_path = try!(config_file_handler::current_bin_dir());
-    config_path.push(try!(get_file_name()));
-    let mut file = try!(::std::fs::File::create(&config_path));
-    try!(write!(&mut file,
-                "{}",
-                ::rustc_serialize::json::as_pretty_json(&config)));
-    try!(file.sync_all());
+    let mut config_path = config_file_handler::current_bin_dir()?;
+    config_path.push(get_file_name()?);
+    let mut file = ::std::fs::File::create(&config_path)?;
+    write!(&mut file,
+           "{}",
+           ::rustc_serialize::json::as_pretty_json(&config))?;
+    file.sync_all()?;
     Ok(config_path)
 }
 
 fn get_file_name() -> ::Res<OsString> {
-    let mut name = try!(config_file_handler::exe_file_stem());
+    let mut name = config_file_handler::exe_file_stem()?;
     name.push(".crust.config");
     Ok(name)
 }

--- a/src/main/config_handler.rs
+++ b/src/main/config_handler.rs
@@ -15,20 +15,30 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use std::ffi::OsString;
-use std::path::PathBuf;
-use std::collections::HashSet;
 
 use common::{SocketAddr, IpAddr};
 use config_file_handler::{self, FileHandler};
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::path::PathBuf;
 
+/// Bootstrap config
 #[derive(PartialEq, Eq, Debug, RustcDecodable, RustcEncodable, Clone)]
 pub struct Config {
+    /// Direct contacts one should connect to
     pub hard_coded_contacts: Vec<SocketAddr>,
+    /// Port for TCP acceptor
     pub tcp_acceptor_port: Option<u16>,
+    /// Port for service discovery on local network
     pub service_discovery_port: Option<u16>,
+    /// File for bootstrap cache
     pub bootstrap_cache_name: Option<String>,
+    /// Bootstrap whitelisted IPs
     pub bootstrap_whitelisted_ips: HashSet<IpAddr>,
+    /// Network ID
+    ///
+    /// This is a mechanism to prevent nodes from different decentralized
+    /// networks to connect to each other (issue #209)
     pub network_name: Option<String>,
 }
 

--- a/src/main/connect/exchange_msg.rs
+++ b/src/main/connect/exchange_msg.rs
@@ -43,7 +43,7 @@ impl ExchangeMsg {
                  socket: Socket,
                  our_id: PeerId,
                  expected_id: PeerId,
-                 name_hash: u64,
+                 name_hash: NameHash,
                  cm: ConnectionMap,
                  finish: Finish)
                  -> ::Res<Token> {

--- a/src/main/connect/exchange_msg.rs
+++ b/src/main/connect/exchange_msg.rs
@@ -49,10 +49,10 @@ impl ExchangeMsg {
                  -> ::Res<Token> {
         let token = core.get_new_token();
 
-        try!(el.register(&socket,
-                         token,
-                         EventSet::error() | EventSet::hup() | EventSet::writable(),
-                         PollOpt::edge()));
+        el.register(&socket,
+                      token,
+                      EventSet::error() | EventSet::hup() | EventSet::writable(),
+                      PollOpt::edge())?;
 
         {
             let mut guard = unwrap!(cm.lock());

--- a/src/main/connect/mod.rs
+++ b/src/main/connect/mod.rs
@@ -67,7 +67,7 @@ impl Connect {
 
         let state = Rc::new(RefCell::new(Connect {
             token: token,
-            timeout: try!(el.timeout_ms(CoreTimerId::new(token, 0), TIMEOUT_MS)),
+            timeout: el.timeout_ms(CoreTimerId::new(token, 0), TIMEOUT_MS)?,
             cm: cm,
             our_nh: our_nh,
             our_id: our_ci.id,
@@ -84,12 +84,12 @@ impl Connect {
             .filter_map(|elt| Socket::connect(&elt).ok())
             .collect::<Vec<_>>();
 
-        if let Ok((listener, nat_sockets)) = nat::get_sockets(our_ci.hole_punch_socket,
-                                                              their_hole_punch.len()) {
-            try!(el.register(&listener,
-                             token,
-                             EventSet::readable() | EventSet::error() | EventSet::hup(),
-                             PollOpt::edge()));
+        if let Ok((listener, nat_sockets)) =
+            nat::get_sockets(our_ci.hole_punch_socket, their_hole_punch.len()) {
+            el.register(&listener,
+                          token,
+                          EventSet::readable() | EventSet::error() | EventSet::hup(),
+                          PollOpt::edge())?;
             state.borrow_mut().listener = Some(listener);
             sockets.extend(nat_sockets.into_iter()
                 .zip(their_hole_punch.into_iter().map(|elt| elt.0))

--- a/src/main/connection_listener/exchange_msg.rs
+++ b/src/main/connection_listener/exchange_msg.rs
@@ -52,10 +52,10 @@ impl ExchangeMsg {
         let token = core.get_new_token();
 
         let es = EventSet::error() | EventSet::hup() | EventSet::readable();
-        try!(el.register(&socket, token, es, PollOpt::edge()));
+        el.register(&socket, token, es, PollOpt::edge())?;
 
-        let timeout = try!(el.timeout_ms(CoreTimerId::new(token, 0),
-                                         timeout_ms.unwrap_or(EXCHANGE_MSG_TIMEOUT_MS)));
+        let timeout = el.timeout_ms(CoreTimerId::new(token, 0),
+                        timeout_ms.unwrap_or(EXCHANGE_MSG_TIMEOUT_MS))?;
 
         let state = ExchangeMsg {
             token: token,

--- a/src/main/connection_listener/exchange_msg.rs
+++ b/src/main/connection_listener/exchange_msg.rs
@@ -32,7 +32,7 @@ pub struct ExchangeMsg {
     token: Token,
     cm: ConnectionMap,
     event_tx: ::CrustEventSender,
-    name_hash: u64,
+    name_hash: NameHash,
     next_state: NextState,
     our_pk: PublicKey,
     socket: Socket,

--- a/src/main/connection_listener/mod.rs
+++ b/src/main/connection_listener/mod.rs
@@ -176,6 +176,7 @@ mod test {
     use mio::{EventLoop, Sender, Token};
     use nat::MappingContext;
     use rust_sodium::crypto::box_::{self, PublicKey};
+    use rust_sodium::crypto::hash::sha256;
     use rustc_serialize::Decodable;
 
     use std::collections::HashMap;
@@ -189,7 +190,8 @@ mod test {
     use super::*;
     use super::exchange_msg::EXCHANGE_MSG_TIMEOUT_MS;
 
-    const NAME_HASH: NameHash = 9876543210;
+    const NAME_HASH: NameHash = [1; sha256::DIGESTBYTES];
+    const NAME_HASH_2: NameHash = [2; sha256::DIGESTBYTES];
 
     struct Listener {
         tx: Sender<CoreMessage>,
@@ -357,7 +359,7 @@ mod test {
     fn bootstrap_with_invalid_version_hash() {
         let listener = start_listener();
         let (pk, _) = box_::gen_keypair();
-        bootstrap(NAME_HASH - 1, pk, listener);
+        bootstrap(NAME_HASH_2, pk, listener);
     }
 
     #[test]
@@ -365,7 +367,7 @@ mod test {
     fn connect_with_invalid_version_hash() {
         let listener = start_listener();
         let (pk, _) = box_::gen_keypair();
-        connect(NAME_HASH - 1, pk, listener);
+        connect(NAME_HASH_2, pk, listener);
     }
 
     #[test]

--- a/src/nat/mapped_tcp_socket/get_ext_addr.rs
+++ b/src/nat/mapped_tcp_socket/get_ext_addr.rs
@@ -44,9 +44,9 @@ impl GetExtAddr {
                  peer_stun: &SocketAddr,
                  finish: Finish)
                  -> Result<Token, NatError> {
-        let query_socket = try!(util::new_reusably_bound_tcp_socket(&local_addr));
-        let query_socket = try!(query_socket.to_tcp_stream());
-        let socket = try!(TcpStream::connect_stream(query_socket, peer_stun));
+        let query_socket = util::new_reusably_bound_tcp_socket(&local_addr)?;
+        let query_socket = query_socket.to_tcp_stream()?;
+        let socket = TcpStream::connect_stream(query_socket, peer_stun)?;
 
         let socket = Socket::wrap(socket);
         let token = core.get_new_token();
@@ -58,10 +58,10 @@ impl GetExtAddr {
             finish: finish,
         };
 
-        try!(el.register(&state.socket,
-                         token,
-                         EventSet::error() | EventSet::hup() | EventSet::writable(),
-                         PollOpt::edge()));
+        el.register(&state.socket,
+                      token,
+                      EventSet::error() | EventSet::hup() | EventSet::writable(),
+                      PollOpt::edge())?;
 
         let _ = core.insert_state(token, Rc::new(RefCell::new(state)));
 

--- a/src/nat/mapped_tcp_socket/mod.rs
+++ b/src/nat/mapped_tcp_socket/mod.rs
@@ -59,8 +59,8 @@ impl<F> MappedTcpSocket<F>
         // TODO(Spandan) Ipv6 is not supported in Listener so dealing only with ipv4 right now
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
 
-        let socket = try!(util::new_reusably_bound_tcp_socket(&addr));
-        let addr = try!(util::tcp_builder_local_addr(&socket));
+        let socket = util::new_reusably_bound_tcp_socket(&addr)?;
+        let addr = util::tcp_builder_local_addr(&socket)?;
 
         // Ask IGD
         let mut igd_children = 0;
@@ -107,7 +107,7 @@ impl<F> MappedTcpSocket<F>
             igd_children: igd_children,
             stun_children: HashSet::with_capacity(mc.peer_stuns().len()),
             mapped_addrs: mapped_addrs,
-            timeout: try!(el.timeout_ms(CoreTimerId::new(token, 0), TIMEOUT_MS)),
+            timeout: el.timeout_ms(CoreTimerId::new(token, 0), TIMEOUT_MS)?,
             finish: Some(finish),
         }));
 

--- a/src/nat/mapping_context.rs
+++ b/src/nat/mapping_context.rs
@@ -37,7 +37,7 @@ pub struct MappingContext {
 impl MappingContext {
     /// Create a new `MappingContext`
     pub fn new() -> Result<MappingContext, NatError> {
-        let ifs = try!(get_if_addrs::get_if_addrs());
+        let ifs = get_if_addrs::get_if_addrs()?;
         let (mut ifv4s, mut ifv6s) = (Vec::with_capacity(5), Vec::with_capacity(5));
         for interface in ifs {
             match interface.addr {

--- a/src/nat/punch_hole.rs
+++ b/src/nat/punch_hole.rs
@@ -24,16 +24,16 @@ use std::net::TcpStream;
 pub fn get_sockets(mapped_socket: TcpBuilder,
                    required: usize)
                    -> Result<(TcpListener, Vec<TcpStream>), NatError> {
-    let local_addr = try!(util::tcp_builder_local_addr(&mapped_socket));
+    let local_addr = util::tcp_builder_local_addr(&mapped_socket)?;
     let mut unconnected_sockets = Vec::with_capacity(required);
     for _ in 0..required {
-        let socket = try!(util::new_reusably_bound_tcp_socket(&local_addr));
-        let socket = try!(socket.to_tcp_stream());
+        let socket = util::new_reusably_bound_tcp_socket(&local_addr)?;
+        let socket = socket.to_tcp_stream()?;
         unconnected_sockets.push(socket);
     }
 
-    let listener = try!(mapped_socket.listen(100));
-    let listener = try!(TcpListener::from_listener(listener, &local_addr));
+    let listener = mapped_socket.listen(100)?;
+    let listener = TcpListener::from_listener(listener, &local_addr)?;
 
     Ok((listener, unconnected_sockets))
 }

--- a/src/nat/util.rs
+++ b/src/nat/util.rs
@@ -22,12 +22,12 @@ use std::net::{self, IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 pub fn new_reusably_bound_tcp_socket(local_addr: &SocketAddr) -> io::Result<TcpBuilder> {
     let socket = match local_addr.ip() {
-        IpAddr::V4(..) => try!(TcpBuilder::new_v4()),
-        IpAddr::V6(..) => try!(TcpBuilder::new_v6()),
+        IpAddr::V4(..) => TcpBuilder::new_v4()?,
+        IpAddr::V6(..) => TcpBuilder::new_v6()?,
     };
-    let _ = try!(socket.reuse_address(true));
-    try!(enable_so_reuseport(&socket));
-    let _ = try!(socket.bind(local_addr));
+    let _ = socket.reuse_address(true)?;
+    enable_so_reuseport(&socket)?;
+    let _ = socket.bind(local_addr)?;
 
     Ok(socket)
 }
@@ -35,7 +35,7 @@ pub fn new_reusably_bound_tcp_socket(local_addr: &SocketAddr) -> io::Result<TcpB
 #[cfg(target_family = "unix")]
 pub fn enable_so_reuseport(sock: &TcpBuilder) -> io::Result<()> {
     use net2::unix::UnixTcpBuilderExt;
-    let _ = try!(sock.reuse_port(true));
+    let _ = sock.reuse_port(true)?;
     Ok(())
 }
 


### PR DESCRIPTION
There was the pub `Service::with_config` method. However, this method
was unusable as the `config` argument as the structure itself was
private. This commit fixes that.