### PR TITLE
feat/bootstrap: enforce external reachability

### DIFF
--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -15,13 +15,13 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use common::{self, NameHash};
+use common::{self, ExternalReachability, NameHash};
 use rust_sodium::crypto::box_::PublicKey;
 
 #[derive(Clone, PartialEq, Eq, Debug, RustcEncodable, RustcDecodable)]
 pub enum Message {
     Heartbeat,
-    BootstrapRequest(PublicKey, NameHash),
+    BootstrapRequest(PublicKey, NameHash, ExternalReachability),
     BootstrapResponse(PublicKey),
     EchoAddrReq,
     EchoAddrResp(common::SocketAddr),

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -37,6 +37,25 @@ pub const MAX_PAYLOAD_SIZE: usize = 2 * 1024 * 1024;
 /// Minimum priority for droppable messages. Messages with lower values will never be dropped.
 pub const MSG_DROP_PRIORITY: u8 = 2;
 
+/// Specify crust user. Behaviour (for example in bootstrap phase) will be different for different
+/// variants. Node will request the Bootstrapee to connect back to this crust failing which it
+/// would mean it's not reachable from outside and hence should be rejected bootstrap attempts.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum CrustUser {
+    /// Crust user is a Node and should not be allowed to bootstrap if it's not reachable from
+    /// outside.
+    Node,
+    /// Crust user is a Client and should be allowed to bootstrap even if it's not reachable from
+    /// outside.
+    Client,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, RustcEncodable, RustcDecodable)]
+pub enum ExternalReachability {
+    NotRequired,
+    Required { direct_listeners: Vec<SocketAddr> },
+}
+
 pub mod get_if_addrs;
 mod core;
 mod error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ mod common;
 mod service_discovery;
 mod nat;
 
-pub use common::{MSG_DROP_PRIORITY, Priority};
+pub use common::{CrustUser, MSG_DROP_PRIORITY, Priority};
 pub use main::{Config, ConnectionInfoResult, CrustError, Event, PeerId, PrivConnectionInfo,
                PubConnectionInfo, Service};
 

--- a/src/main/bootstrap/mod.rs
+++ b/src/main/bootstrap/mod.rs
@@ -20,7 +20,7 @@ mod try_peer;
 
 use self::cache::Cache;
 use self::try_peer::TryPeer;
-use common::{self, Core, CoreTimerId, NameHash, Socket, State};
+use common::{self, Core, CoreTimerId, ExternalReachability, NameHash, Socket, State};
 
 use main::{ActiveConnection, Config, ConnectionMap, CrustError, Event, PeerId};
 use mio::{EventLoop, Timeout, Token};
@@ -47,6 +47,7 @@ pub struct Bootstrap {
     peers: Vec<common::SocketAddr>,
     blacklist: HashSet<net::SocketAddr>,
     name_hash: NameHash,
+    ext_reachability: ExternalReachability,
     our_pk: PublicKey,
     event_tx: ::CrustEventSender,
     sd_meta: Option<ServiceDiscMeta>,
@@ -61,6 +62,7 @@ impl Bootstrap {
     pub fn start(core: &mut Core,
                  el: &mut EventLoop<Core>,
                  name_hash: NameHash,
+                 ext_reachability: ExternalReachability,
                  our_pk: PublicKey,
                  cm: ConnectionMap,
                  config: &Config,
@@ -97,6 +99,7 @@ impl Bootstrap {
             peers: peers,
             blacklist: blacklist,
             name_hash: name_hash,
+            ext_reachability: ext_reachability,
             our_pk: our_pk,
             event_tx: event_tx,
             sd_meta: sd_meta,
@@ -140,6 +143,7 @@ impl Bootstrap {
                                               *peer,
                                               self.our_pk,
                                               self.name_hash,
+                                              self.ext_reachability.clone(),
                                               Box::new(finish)) {
                 let _ = self.children.insert(child);
             }

--- a/src/main/bootstrap/try_peer.rs
+++ b/src/main/bootstrap/try_peer.rs
@@ -15,8 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-
-use common::{Core, Message, NameHash, Priority, Socket, State};
+use common::{Core, ExternalReachability, Message, NameHash, Priority, Socket, State};
 use main::PeerId;
 use mio::{EventLoop, EventSet, PollOpt, Token};
 use rust_sodium::crypto::box_::PublicKey;
@@ -48,6 +47,7 @@ impl TryPeer {
                  peer: SocketAddr,
                  our_pk: PublicKey,
                  name_hash: NameHash,
+                 ext_reachability: ExternalReachability,
                  finish: Finish)
                  -> ::Res<Token> {
         let socket = Socket::connect(&peer)?;
@@ -62,7 +62,7 @@ impl TryPeer {
             token: token,
             peer: peer,
             socket: socket,
-            request: Some((Message::BootstrapRequest(our_pk, name_hash), 0)),
+            request: Some((Message::BootstrapRequest(our_pk, name_hash, ext_reachability), 0)),
             finish: finish,
         };
 

--- a/src/main/connect/mod.rs
+++ b/src/main/connect/mod.rs
@@ -84,18 +84,20 @@ impl Connect {
             .filter_map(|elt| Socket::connect(&elt).ok())
             .collect::<Vec<_>>();
 
-        if let Ok((listener, nat_sockets)) =
-            nat::get_sockets(our_ci.hole_punch_socket, their_hole_punch.len()) {
-            el.register(&listener,
-                          token,
-                          EventSet::readable() | EventSet::error() | EventSet::hup(),
-                          PollOpt::edge())?;
-            state.borrow_mut().listener = Some(listener);
-            sockets.extend(nat_sockets.into_iter()
-                .zip(their_hole_punch.into_iter().map(|elt| elt.0))
-                .filter_map(|elt| TcpStream::connect_stream(elt.0, &elt.1).ok())
-                .map(Socket::wrap)
-                .collect::<Vec<_>>());
+        if let Some(hole_punch_sock) = our_ci.hole_punch_socket {
+            if let Ok((listener, nat_sockets)) =
+                nat::get_sockets(hole_punch_sock, their_hole_punch.len()) {
+                el.register(&listener,
+                              token,
+                              EventSet::readable() | EventSet::error() | EventSet::hup(),
+                              PollOpt::edge())?;
+                state.borrow_mut().listener = Some(listener);
+                sockets.extend(nat_sockets.into_iter()
+                    .zip(their_hole_punch.into_iter().map(|elt| elt.0))
+                    .filter_map(|elt| TcpStream::connect_stream(elt.0, &elt.1).ok())
+                    .map(Socket::wrap)
+                    .collect::<Vec<_>>());
+            }
         }
 
         for socket in sockets {

--- a/src/main/connection_listener/check_reachability.rs
+++ b/src/main/connection_listener/check_reachability.rs
@@ -1,0 +1,108 @@
+// Copyright 2016 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement, version 1.0.  This, along with the
+// Licenses can be found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+use common::{Core, CoreTimerId, Socket, SocketAddr, State};
+use mio::{EventLoop, EventSet, PollOpt, Timeout, Token};
+use std::any::Any;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+const CHECK_REACHABILITY_TIMEOUT_MS: u64 = 3 * 1000;
+
+pub type Finish<T> = Box<FnMut(&mut Core, &mut EventLoop<Core>, Token, Result<T, ()>)>;
+
+pub struct CheckReachability<T> {
+    token: Token,
+    socket: Socket,
+    timeout: Timeout,
+    finish: Finish<T>,
+    t: T,
+}
+
+impl<T> CheckReachability<T>
+    where T: 'static + Clone
+{
+    pub fn start(core: &mut Core,
+                 el: &mut EventLoop<Core>,
+                 their_listener: SocketAddr,
+                 t: T,
+                 finish: Finish<T>)
+                 -> ::Res<Token> {
+        let socket = Socket::connect(&their_listener)?;
+        let token = core.get_new_token();
+
+        el.register(&socket,
+                      token,
+                      EventSet::error() | EventSet::hup() | EventSet::writable(),
+                      PollOpt::edge())?;
+
+        let timeout = el.timeout_ms(CoreTimerId::new(token, 0), CHECK_REACHABILITY_TIMEOUT_MS)?;
+
+        let state = CheckReachability {
+            token: token,
+            socket: socket,
+            timeout: timeout,
+            finish: finish,
+            t: t,
+        };
+
+        let _ = core.insert_state(token, Rc::new(RefCell::new(state)));
+
+        Ok(token)
+    }
+
+    fn handle_success(&mut self, core: &mut Core, el: &mut EventLoop<Core>) {
+        self.terminate(core, el);
+        let token = self.token;
+        let t = self.t.clone();
+        (*self.finish)(core, el, token, Ok(t));
+    }
+
+    fn handle_error(&mut self, core: &mut Core, el: &mut EventLoop<Core>) {
+        self.terminate(core, el);
+        let token = self.token;
+        (*self.finish)(core, el, token, Err(()));
+    }
+}
+
+impl<T> State for CheckReachability<T>
+    where T: 'static + Clone
+{
+    fn ready(&mut self, core: &mut Core, el: &mut EventLoop<Core>, es: EventSet) {
+        if es.is_error() || es.is_hup() || !es.is_writable() {
+            self.handle_error(core, el);
+        } else {
+            self.handle_success(core, el);
+        }
+    }
+
+    fn terminate(&mut self, core: &mut Core, el: &mut EventLoop<Core>) {
+        let _ = el.clear_timeout(self.timeout);
+        let _ = core.remove_state(self.token);
+        let _ = el.deregister(&self.socket);
+    }
+
+    fn timeout(&mut self, core: &mut Core, el: &mut EventLoop<Core>, _timer_id: u8) {
+        trace!("Bootstrapper is external reachability timed out to one of the given IP's. \
+                Erroring out for this remote endpoint.");
+        self.handle_error(core, el)
+    }
+
+    fn as_any(&mut self) -> &mut Any {
+        self
+    }
+}

--- a/src/main/connection_listener/exchange_msg.rs
+++ b/src/main/connection_listener/exchange_msg.rs
@@ -158,7 +158,10 @@ impl ExchangeMsg {
 
                 child.borrow_mut().terminate(core, el);
             }
-            return self.send_bootstrap_resp(core, el, state_data.their_public_key, state_data.name_hash);
+            return self.send_bootstrap_resp(core,
+                                            el,
+                                            state_data.their_public_key,
+                                            state_data.name_hash);
         }
         if self.reachability_children.is_empty() {
             debug!("Bootstrapper failed to pass requisite condition of external recheability. \

--- a/src/main/types.rs
+++ b/src/main/types.rs
@@ -85,7 +85,7 @@ pub struct PrivConnectionInfo {
     #[doc(hidden)]
     pub for_hole_punch: Vec<common::SocketAddr>,
     #[doc(hidden)]
-    pub hole_punch_socket: TcpBuilder,
+    pub hole_punch_socket: Option<TcpBuilder>,
 }
 
 impl PrivConnectionInfo {

--- a/src/nat/mapped_tcp_socket/mod.rs
+++ b/src/nat/mapped_tcp_socket/mod.rs
@@ -113,9 +113,6 @@ impl<F> MappedTcpSocket<F>
 
         // Ask Stuns
         for stun in mc.peer_stuns() {
-            if true {
-                break;
-            }
             let self_weak = Rc::downgrade(&state);
             let handler = move |core: &mut Core, el: &mut EventLoop<Core>, child_token, res| {
                 if let Some(self_rc) = self_weak.upgrade() {


### PR DESCRIPTION
If node then enforce external reachability, else deny bootstrap.
Mapped TCP socket is switched off for prepare-connection-info - so no hole punching or igd, only connection via direct tcp listeners.