### PR TITLE
feat/bootstrap: send bootstrap deny

### DIFF
--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -22,10 +22,17 @@ use rust_sodium::crypto::box_::PublicKey;
 pub enum Message {
     Heartbeat,
     BootstrapRequest(PublicKey, NameHash, ExternalReachability),
-    BootstrapResponse(PublicKey),
+    BootstrapGranted(PublicKey),
+    BootstrapDenied(BootstrapDenyReason),
     EchoAddrReq,
     EchoAddrResp(common::SocketAddr),
     ChooseConnection,
     Connect(PublicKey, NameHash),
     Data(Vec<u8>),
+}
+
+#[derive(Clone, PartialEq, Eq, Debug, RustcEncodable, RustcDecodable)]
+pub enum BootstrapDenyReason {
+    InvalidNameHash,
+    FailedExternalReachability,
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -19,7 +19,7 @@
 
 pub use self::core::{Core, CoreMessage, CoreTimerId};
 pub use self::error::CommonError;
-pub use self::message::Message;
+pub use self::message::{BootstrapDenyReason, Message};
 pub use self::socket::Socket;
 pub use self::socket_addr::{IpAddr, SocketAddr};
 pub use self::state::State;

--- a/src/main/bootstrap/mod.rs
+++ b/src/main/bootstrap/mod.rs
@@ -175,7 +175,13 @@ impl Bootstrap {
             Err((bad_peer, opt_reason)) => {
                 self.cache.remove_peer_acceptor(common::SocketAddr(bad_peer));
                 if let Some(reason) = opt_reason {
-                    error!("Failed to Bootstrap: {:?}", reason);
+                    let err_msg = match reason {
+                        BootstrapDenyReason::InvalidNameHash => "Network name mismatch.",
+                        BootstrapDenyReason::FailedExternalReachability => {
+                            "Bootstrapee node could not establish connection to us."
+                        }
+                    };
+                    error!("Failed to Bootstrap: ({:?}) {}", reason, err_msg);
                     self.terminate(core, el);
                     let _ = self.event_tx.send(Event::BootstrapFailed);
                     return;

--- a/src/main/connect/exchange_msg.rs
+++ b/src/main/connect/exchange_msg.rs
@@ -62,6 +62,9 @@ impl ExchangeMsg {
                     currently_handshaking: 0,
                 })
                 .currently_handshaking += 1;
+            trace!("Connection Map inserted: {:?} -> {:?}",
+                   expected_id,
+                   guard.get(&expected_id));
         }
 
         let state = ExchangeMsg {
@@ -138,6 +141,9 @@ impl State for ExchangeMsg {
                 let _ = oe.remove();
             }
         }
+        trace!("Connection Map removed: {:?} -> {:?}",
+               self.expected_id,
+               guard.get(&self.expected_id));
     }
 
     fn as_any(&mut self) -> &mut Any {

--- a/src/main/connection_candidate.rs
+++ b/src/main/connection_candidate.rs
@@ -138,6 +138,9 @@ impl State for ConnectionCandidate {
                 let _ = oe.remove();
             }
         }
+        trace!("Connection Map removed: {:?} -> {:?}",
+               self.their_id,
+               guard.get(&self.their_id));
     }
 
     fn as_any(&mut self) -> &mut Any {

--- a/src/main/connection_listener/check_reachability.rs
+++ b/src/main/connection_listener/check_reachability.rs
@@ -97,7 +97,7 @@ impl<T> State for CheckReachability<T>
     }
 
     fn timeout(&mut self, core: &mut Core, el: &mut EventLoop<Core>, _timer_id: u8) {
-        trace!("Bootstrapper is external reachability timed out to one of the given IP's. \
+        trace!("Bootstrapper's external reachability check timed out to one of its given IP's. \
                 Erroring out for this remote endpoint.");
         self.handle_error(core, el)
     }

--- a/src/main/connection_listener/exchange_msg.rs
+++ b/src/main/connection_listener/exchange_msg.rs
@@ -226,6 +226,9 @@ impl ExchangeMsg {
                 currently_handshaking: 0,
             })
             .currently_handshaking += 1;
+        trace!("Connection Map inserted: {:?} -> {:?}",
+               their_id,
+               guard.get(&their_id));
     }
 
     fn is_valid_name_hash(&self, name_hash: NameHash) -> bool {
@@ -346,6 +349,9 @@ impl State for ExchangeMsg {
                         let _ = oe.remove();
                     }
                 }
+                trace!("Connection Map removed: {:?} -> {:?}",
+                       their_id,
+                       guard.get(&their_id));
             }
             NextState::None => (),
         }

--- a/src/main/connection_listener/exchange_msg.rs
+++ b/src/main/connection_listener/exchange_msg.rs
@@ -101,12 +101,12 @@ impl ExchangeMsg {
             }
             Ok(Some(Message::EchoAddrReq)) => self.handle_echo_addr_req(core, el),
             Ok(Some(message)) => {
-                warn!("Unexpected message in direct connect: {:?}", message);
+                debug!("Unexpected message in direct connect: {:?}", message);
                 self.terminate(core, el)
             }
             Ok(None) => (),
             Err(error) => {
-                error!("Failed to read from socket: {:?}", error);
+                debug!("Failed to read from socket: {:?}", error);
                 self.terminate(core, el);
             }
         }
@@ -237,7 +237,7 @@ impl ExchangeMsg {
 
     fn get_peer_id(&self, their_public_key: PublicKey) -> Result<PeerId, ()> {
         if self.our_pk == their_public_key {
-            warn!("Accepted connection from ourselves");
+            debug!("Accepted connection from ourselves");
             return Err(());
         }
 
@@ -265,7 +265,7 @@ impl ExchangeMsg {
             Ok(true) => self.done(core, el),
             Ok(false) => (),
             Err(e) => {
-                warn!("Error in writting: {:?}", e);
+                debug!("Error in writting: {:?}", e);
                 self.terminate(core, el)
             }
         }

--- a/src/main/connection_listener/mod.rs
+++ b/src/main/connection_listener/mod.rs
@@ -131,12 +131,12 @@ impl ConnectionListener {
                                                        self.name_hash,
                                                        self.cm.clone(),
                                                        self.event_tx.clone()) {
-                        warn!("Error accepting direct connection: {:?}", e);
+                        debug!("Error accepting direct connection: {:?}", e);
                     }
                 }
                 Ok(None) => return,
                 Err(err) => {
-                    warn!("Failed to accept new socket: {:?}", err);
+                    debug!("Failed to accept new socket: {:?}", err);
                     return;
                 }
             }

--- a/src/main/connection_listener/mod.rs
+++ b/src/main/connection_listener/mod.rs
@@ -306,7 +306,7 @@ mod tests {
         unwrap!(write(&mut us, message), "Could not write.");
 
         match unwrap!(read(&mut us), "Could not read.") {
-            Message::BootstrapResponse(peer_pk) => assert_eq!(peer_pk, listener.pk),
+            Message::BootstrapGranted(peer_pk) => assert_eq!(peer_pk, listener.pk),
             msg => panic!("Unexpected message: {:?}", msg),
         }
 

--- a/src/main/service.rs
+++ b/src/main/service.rs
@@ -112,7 +112,7 @@ impl Service {
                                                     our_listeners,
                                                     SERVICE_DISCOVERY_TOKEN,
                                                     port) {
-                warn!("Could not start ServiceDiscovery: {:?}", e);
+                debug!("Could not start ServiceDiscovery: {:?}", e);
             }
         });
     }
@@ -327,8 +327,8 @@ impl Service {
     ///    obtained from the peer
     pub fn connect(&self, our_ci: PrivConnectionInfo, their_ci: PubConnectionInfo) -> ::Res<()> {
         if unwrap!(self.cm.lock()).contains_key(&their_ci.id) {
-            warn!("Already connected OR already in process of connecting to {:?}",
-                  their_ci.id);
+            debug!("Already connected OR already in process of connecting to {:?}",
+                   their_ci.id);
             return Ok(());
         }
 

--- a/src/service_discovery/mod.rs
+++ b/src/service_discovery/mod.rs
@@ -115,7 +115,7 @@ impl ServiceDiscovery {
             Ok(None) => return,
             Err(ref e) if e.kind() == ErrorKind::Interrupted => return,
             Err(e) => {
-                warn!("ServiceDiscovery error in read: {:?}", e);
+                debug!("ServiceDiscovery error in read: {:?}", e);
                 self.terminate(core, el);
                 return;
             }
@@ -124,7 +124,7 @@ impl ServiceDiscovery {
         let msg: DiscoveryMsg = match deserialise(&self.read_buf[..bytes_rxd]) {
             Ok(msg) => msg,
             Err(e) => {
-                warn!("Bogus message serialisation error: {:?}", e);
+                debug!("Bogus message serialisation error: {:?}", e);
                 return;
             }
         };
@@ -144,7 +144,7 @@ impl ServiceDiscovery {
 
     fn write(&mut self, core: &mut Core, el: &mut EventLoop<Core>) {
         if let Err(e) = self.write_impl(el) {
-            warn!("Error in ServiceDiscovery write: {:?}", e);
+            debug!("Error in ServiceDiscovery write: {:?}", e);
             self.terminate(core, el);
         }
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -347,7 +347,7 @@ mod broken_peer {
                         let public_key = box_::gen_keypair().0;
                         unwrap!(self.0.write(el,
                                                     self.1,
-                                                    Some((Message::BootstrapResponse(public_key),
+                                                    Some((Message::BootstrapGranted(public_key),
                                                           0))));
                     }
                     Some(_) | None => (),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -62,10 +62,7 @@ fn bootstrap_two_services_and_exchange_messages() {
     let (event_tx1, event_rx1) = get_event_sender();
     let mut service1 = unwrap!(Service::with_config(event_tx1, config1));
 
-    unwrap!(service1.start_listening_tcp());
-    let _ = expect_event!(event_rx1, Event::ListenerStarted(port) => port);
-
-    unwrap!(service1.start_bootstrap(HashSet::new(), CrustUser::Node));
+    unwrap!(service1.start_bootstrap(HashSet::new(), CrustUser::Client));
 
     let peer_id0 = expect_event!(event_rx1, Event::BootstrapConnect(peer_id, _) => peer_id);
     assert_eq!(peer_id0, service0.id());
@@ -259,10 +256,7 @@ fn drop_disconnects() {
     let (event_tx_1, event_rx_1) = get_event_sender();
     let mut service_1 = unwrap!(Service::with_config(event_tx_1, config_1));
 
-    unwrap!(service_1.start_listening_tcp());
-    let _ = expect_event!(event_rx_1, Event::ListenerStarted(port) => port);
-
-    unwrap!(service_1.start_bootstrap(HashSet::new(), CrustUser::Node));
+    unwrap!(service_1.start_bootstrap(HashSet::new(), CrustUser::Client));
 
     let peer_id_0 = expect_event!(event_rx_1, Event::BootstrapConnect(peer_id, _) => peer_id);
     expect_event!(event_rx_0, Event::BootstrapAccept(_peer_id));
@@ -402,7 +396,7 @@ fn drop_peer_when_no_message_received_within_inactivity_period() {
     let (event_tx, event_rx) = get_event_sender();
     let mut service = unwrap!(Service::with_config(event_tx, config));
 
-    unwrap!(service.start_bootstrap(HashSet::new(), CrustUser::Node));
+    unwrap!(service.start_bootstrap(HashSet::new(), CrustUser::Client));
     let peer_id = expect_event!(event_rx, Event::BootstrapConnect(peer_id, _) => peer_id);
 
     // The peer should drop after inactivity.
@@ -432,10 +426,7 @@ fn do_not_drop_peer_even_when_no_data_messages_are_exchanged_within_inactivity_p
     let (event_tx1, event_rx1) = get_event_sender();
     let mut service1 = unwrap!(Service::with_config(event_tx1, config1));
 
-    unwrap!(service1.start_listening_tcp());
-    let _ = expect_event!(event_rx1, Event::ListenerStarted(port) => port);
-
-    unwrap!(service1.start_bootstrap(HashSet::new(), CrustUser::Node));
+    unwrap!(service1.start_bootstrap(HashSet::new(), CrustUser::Client));
     expect_event!(event_rx1, Event::BootstrapConnect(_peer_id, _));
     expect_event!(event_rx0, Event::BootstrapAccept(_peer_id));
 


### PR DESCRIPTION
1) Create new crust msg - BootstrapDeny and create reason enum for denial.
2) If the bootstrapper fails either name hash check or external reachability check, then explicitly send a deny msg before disconnecting it.
3) Bootstrapper on getting an expliciy bootstrap deny will echo the reason and immediately terminate bootstrap raising failed event, not waiting for the complete parallel bootstrap process to indicate eventual success or failure, i.e., all children working in parallel are immediately terminated.

Note: While the existing test cases pass locally, this specific feature is not tested and must have explicit test cases written for it to validate the new behaviour.