### PR TITLE
perf/complexity: avoid traversing vector again

### DIFF
--- a/src/main/active_connection.rs
+++ b/src/main/active_connection.rs
@@ -259,10 +259,10 @@ impl Heartbeat {
             HeartbeatAction::Terminate
         } else {
             core.set_timeout(Duration::from_millis(HEARTBEAT_PERIOD_MS), self.send_timer)
-                .and_then(|t| {
-                              self.send_timeout = t;
-                              Ok(HeartbeatAction::Send)
-                          })
+                .map(|t| {
+                         self.send_timeout = t;
+                         HeartbeatAction::Send
+                     })
                 .unwrap_or_else(|e| {
                                     debug!("Failed to reschedule heartbeat send timer: {:?}", e);
                                     HeartbeatAction::Terminate

--- a/src/main/connection_listener/mod.rs
+++ b/src/main/connection_listener/mod.rs
@@ -62,18 +62,17 @@ impl ConnectionListener {
         let event_tx_0 = event_tx.clone();
         let finish =
             move |core: &mut Core, poll: &Poll, socket, mut mapped_addrs: Vec<SocketAddr>| {
-                if port != 0 && force_include_port &&
+                if force_include_port && port != 0 &&
                    !mapped_addrs.iter().any(|s| ip_addr_is_global(&s.ip()) && s.port() == port) {
-                    let mut global_addrs: Vec<_> = mapped_addrs.iter()
+                    let global_addrs: Vec<_> = mapped_addrs.iter()
                         .filter_map(|s| if ip_addr_is_global(&s.ip()) {
-                                        Some(*s)
+                                        let mut s = *s;
+                                        s.set_port(port);
+                                        Some(s)
                                     } else {
                                         None
                                     })
                         .collect();
-                    for addr in &mut global_addrs {
-                        addr.set_port(port);
-                    }
                     mapped_addrs.extend(global_addrs);
                 }
                 if let Err(e) = ConnectionListener::handle_mapped_socket(core,


### PR DESCRIPTION
Perform operation on the fly during first iteration instead of collecting and traversing again.
Use a better combinator.