### PR TITLE
refactor/config: make read_config_file public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ mod nat;
 
 pub use common::{CrustUser, MSG_DROP_PRIORITY, Priority, Uid};
 pub use main::{Config, ConnectionInfoResult, CrustError, Event, PrivConnectionInfo,
-               PubConnectionInfo, Service};
+               PubConnectionInfo, Service, read_config_file};
 
 /// Used to receive events from a `Service`.
 pub type CrustEventSender<UID> = ::maidsafe_utilities::event_sender::MaidSafeObserver<Event<UID>>;

--- a/src/main/mod.rs
+++ b/src/main/mod.rs
@@ -40,3 +40,5 @@ mod event;
 mod error;
 mod service;
 mod types;
+
+pub use self::config_handler::read_config_file;

--- a/src/main/service.rs
+++ b/src/main/service.rs
@@ -495,11 +495,6 @@ impl<UID: Uid> Service<UID> {
         self.our_uid
     }
 
-    /// Returns our config.
-    pub fn config(&self) -> Config {
-        self.config.clone()
-    }
-
     fn post<F>(&self, f: F) -> ::Res<()>
         where F: FnOnce(&mut Core, &Poll) + Send + 'static
     {


### PR DESCRIPTION
And remove `service.config(&self)` function - use `crust::read_config_file` instead.