### PR TITLE
Data exchange example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,6 @@ igd = "*"
 name = "connect"
 path = "examples/connect.rs"
 
+[[example]]
+name = "exchange_data"
+path = "examples/exchange_data.rs"

--- a/examples/exchange_data.rs
+++ b/examples/exchange_data.rs
@@ -1,0 +1,95 @@
+// Copyright 2017 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+//! This example demonstrates how to exchange data between two P2P nodes.
+//!
+//! In a nutshell all it does is:
+//!
+//! 1. connects to remote peer (for connection details see `connect.rs` sample)
+//! 2. sends "Hello from peer '$peer_id'" message
+//! 3. sends "Goodbye from peer '$peer_id" message
+//! 4. prints any messages received from remote peer
+
+#[macro_use]
+extern crate unwrap;
+extern crate tokio_core;
+extern crate futures;
+extern crate serde;
+extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
+extern crate rand;
+#[macro_use]
+extern crate rand_derive;
+
+extern crate crust;
+
+use futures::future::{Future, empty};
+use futures::sink::Sink;
+use futures::stream::Stream;
+use tokio_core::reactor::Core;
+
+mod utils;
+use utils::{PeerId, connect_to_peer};
+
+fn main() {
+    let mut event_loop = unwrap!(Core::new());
+    // generate random unique ID for this node
+    let service_id = PeerId::random();
+    println!("Service id: {}", service_id);
+
+    // does the p2p connection as demonstrated in `connect.rs` example
+    let peer = connect_to_peer(&mut event_loop, service_id.clone());
+    println!(
+        "Connected to peer: {}, {}",
+        peer.uid(),
+        unwrap!(peer.addr())
+    );
+
+    let (peer_sink, peer_stream) = peer.split();
+    // spawn an asynchronous task that handles incoming data
+    event_loop.handle().spawn(
+        peer_stream
+            .for_each(|data: Vec<u8>| {
+                println!("Received: {}", unwrap!(String::from_utf8(data)));
+                Ok(()) // keep receiving data
+            })
+            // adapt to Handle::spawn() requirements, see:
+            // https://docs.rs/tokio-core/0.1.10/tokio_core/reactor/struct.Handle.html#method.spawn
+            .then(|_| Ok(())),
+    );
+
+    // lower priority is higher, 0 is the highest.
+    // Note that 0 is used for internal crust messages though.
+    let msg_priority = 1;
+    let hello_msg = format!("Hello from peer '{}'!", service_id).into_bytes();
+    let bye_msg = format!("Goodbye from peer '{}'!", service_id).into_bytes();
+
+    // let's send multiple messages to connected peer
+    unwrap!(event_loop.run(
+        peer_sink
+        .send((msg_priority, hello_msg)) // send first message
+        .and_then(|peer_sink| { // when it's done, send the second
+            // sink.send() on completion returns sink which implements Future trait
+            peer_sink.send((msg_priority, bye_msg))
+        }),
+    ));
+
+    // Run event loop forever.
+    let res = event_loop.run(empty::<(), ()>());
+    unwrap!(res);
+}

--- a/examples/utils.rs
+++ b/examples/utils.rs
@@ -1,0 +1,97 @@
+// Copyright 2017 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under (1) the MaidSafe.net Commercial License,
+// version 1.0 or later, or (2) The General Public License (GPL), version 3, depending on which
+// licence you accepted on initial access to the Software (the "Licences").
+//
+// By contributing code to the SAFE Network Software, or to this project generally, you agree to be
+// bound by the terms of the MaidSafe Contributor Agreement.  This, along with the Licenses can be
+// found in the root directory of this project at LICENSE, COPYING and CONTRIBUTOR.
+//
+// Unless required by applicable law or agreed to in writing, the SAFE Network Software distributed
+// under the GPL Licence is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.
+//
+// Please review the Licences for the specific language governing permissions and limitations
+// relating to use of the SAFE Network Software.
+
+//! Some common utilities to stay DRY (Don't Repeat Yourself).
+
+
+use crust::{ConfigFile, Peer, PubConnectionInfo, Service, Uid};
+
+use rand::{self, Rng};
+use serde_json;
+use std::{fmt, io};
+use std::path::PathBuf;
+use tokio_core::reactor::Core;
+
+/// Reads single line from stdin.
+pub fn readln() -> String {
+    let mut ln = String::new();
+    unwrap!(io::stdin().read_line(&mut ln));
+    String::from(ln.trim())
+}
+
+// Some peer ID boilerplate.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Rand)]
+pub struct PeerId(u64);
+
+impl PeerId {
+    pub fn random() -> PeerId {
+        rand::thread_rng().gen::<PeerId>()
+    }
+}
+
+impl Uid for PeerId {}
+
+impl fmt::Display for PeerId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let PeerId(ref id) = *self;
+        write!(f, "{:x}", id)
+    }
+}
+
+/// Starts accepting peer connections and connects itself to a given peer.
+/// After successful connection peer is returned.
+pub fn connect_to_peer(event_loop: &mut Core, service_id: PeerId) -> Peer<PeerId> {
+    let config =
+        unwrap!(
+        ConfigFile::open_path(PathBuf::from("sample.config")),
+        "Failed to read crust config file: sample.config",
+    );
+    let make_service = Service::with_config(&event_loop.handle(), config, service_id);
+    let service =
+        unwrap!(
+        event_loop.run(make_service),
+        "Failed to create Service object",
+    );
+
+    let listener =
+        unwrap!(
+        event_loop.run(service.start_listener()),
+        "Failed to start listening to peers",
+    );
+    println!("Listening on {}", listener.addr());
+
+    let our_conn_info =
+        unwrap!(
+        event_loop.run(service.prepare_connection_info()),
+        "Failed to prepare connection info",
+    );
+    let pub_conn_info = our_conn_info.to_pub_connection_info();
+    println!(
+        "Public connection information:\n{}\n",
+        unwrap!(serde_json::to_string(&pub_conn_info))
+    );
+
+    println!("Enter remote peer public connection info:");
+    let their_info = readln();
+    let their_info: PubConnectionInfo<PeerId> = unwrap!(serde_json::from_str(&their_info));
+
+    unwrap!(
+        event_loop.run(service.connect(our_conn_info, their_info)),
+        "Failed to connect to given peer",
+    )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,6 @@ pub use config::ConfigFile;
 pub use service::Service;
 pub use error::CrustError;
 pub use common::CrustUser;
-pub use net::{PrivConnectionInfo, PubConnectionInfo};
+pub use net::{PrivConnectionInfo, PubConnectionInfo, Peer};
 pub use net::Uid;
 


### PR DESCRIPTION
Simple example that exchanges data between two connected peers.
This is a continuation of `connect.rs` example.

And that's pretty much how the output of example looks like:

```
Service id: 39cc6b2d7bcb45d6
Listening on 0.0.0.0:39945
Public connection information:
{"id":4164821598505485782,"for_hole_punch":["192.168.0.103:33841","169.254.6.218:33841","172.17.0.1:33841"],"for_direct":["192.168.0.103:39945","172.17.0.1:39945","169.254.6.218:39945"]}

Enter remote peer public connection info:
{"id":10617504132659786080,"for_hole_punch":["172.17.0.1:42485","169.254.6.218:42485","192.168.0.103:42485"],"for_direct":["172.17.0.1:44631","192.168.0.103:44631","169.254.6.218:44631"]}
Connected to peer: 9358f3c1346db160, 172.17.0.1:44631
Received: Hello from peer '9358f3c1346db160'!
Received: Goodbye from peer '9358f3c1346db160'!
```