### PR TITLE
Fix hanging test

### DIFF
--- a/src/tests/compat_api.rs
+++ b/src/tests/compat_api.rs
@@ -15,7 +15,6 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use MAX_PAYLOAD_SIZE;
 use compat::{self, CrustEventSender, Event};
 use config::DevConfigSettings;
 use env_logger;
@@ -132,7 +131,7 @@ fn start_two_services_exchange_data() {
     assert_ne!(port0, port1);
 
     const NUM_MESSAGES: usize = 100;
-    const MAX_DATA_SIZE: usize = MAX_PAYLOAD_SIZE - 8;
+    const MAX_DATA_SIZE: usize = 512;
 
     let uid0 = service0.id();
     let uid1 = service1.id();

--- a/src/tests/compat_api.rs
+++ b/src/tests/compat_api.rs
@@ -131,6 +131,8 @@ fn start_two_services_exchange_data() {
     assert_ne!(port0, port1);
 
     const NUM_MESSAGES: usize = 100;
+    // TODO(povilas): have a test with bigger data buffer sizes (>2MB). Such tests might reveal
+    // other issues.
     const MAX_DATA_SIZE: usize = 512;
 
     let uid0 = service0.id();


### PR DESCRIPTION
During the test 200 buffers of 2 MB are randomized and exchanged between two `Crust` `Services` running on separate threads.
That takes a lot of time. Just buffer randomization consumes about 55 seconds.
I believe we don't need such big buffers to validate data exchange.
This fix reduces the buffers, hence tests don't timeout.