### PR TITLE
Don't filter loopback addrs in Listener

### DIFF
--- a/src/net/listener.rs
+++ b/src/net/listener.rs
@@ -144,11 +144,7 @@ fn listener_addresses(
     public_addr: Option<SocketAddr>,
 ) -> io::Result<(TcpListener, HashSet<SocketAddr>)> {
     listener.expanded_local_addrs().map(|local_addrs| {
-        let mut addrs = local_addrs
-            .iter()
-            .filter(|addr| !addr.ip().is_loopback())
-            .cloned()
-            .collect::<HashSet<SocketAddr>>();
+        let mut addrs = local_addrs.iter().cloned().collect::<HashSet<SocketAddr>>();
         if let Some(public_addr) = public_addr {
             addrs.insert(public_addr);
         }

--- a/src/net/peer/connect/connect.rs
+++ b/src/net/peer/connect/connect.rs
@@ -16,7 +16,7 @@
 // relating to use of the SAFE Network Software.
 
 use future_utils::bi_channel::UnboundedBiChannel;
-use futures::sync::mpsc::{UnboundedReceiver, SendError};
+use futures::sync::mpsc::{SendError, UnboundedReceiver};
 use futures::sync::oneshot;
 use net::peer;
 use net::peer::connect::demux::ConnectMessage;


### PR DESCRIPTION
These already get filtered later on. If we filter them in here then we won't be able to connect over loopback (and also it breaks a test).