### PR TITLE
integrate rendezvous servers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tokio-io = "0.1.3"
 unwrap = "1.1"
 url = "~1.5.1"
 void = "1.0.2"
-tokio-utp = "0.2.7"
+tokio-utp = "~0.2.8"
 bincode = "~0.9.2"
 
 [dependencies.p2p]

--- a/src/net/peer/connect/bootstrap/try_peer.rs
+++ b/src/net/peer/connect/bootstrap/try_peer.rs
@@ -19,6 +19,7 @@ use maidsafe_utilities::serialisation::SerialisationError;
 use net::peer;
 use net::peer::connect::handshake_message::{BootstrapDenyReason, BootstrapRequest,
                                             HandshakeMessage};
+use net::peer::connect::send_request_header;
 use priv_prelude::*;
 
 quick_error! {
@@ -91,6 +92,7 @@ pub fn try_peer<UID: Uid>(
     let handle1 = handle.clone();
     let addr = *addr;
     PaStream::direct_connect(&addr, handle)
+        .and_then(send_request_header)
         .map(move |stream| Socket::wrap_pa(&handle0, stream, addr))
         .with_timeout(Duration::from_secs(10), handle)
         .and_then(|res| res.ok_or_else(|| io::ErrorKind::TimedOut.into()))

--- a/src/net/peer/connect/demux.rs
+++ b/src/net/peer/connect/demux.rs
@@ -116,13 +116,13 @@ fn handle_incoming_connections<UID: Uid>(
     incoming: SocketIncoming,
     inner: &Arc<DemuxInner<UID>>,
 ) -> BoxFuture<(), ()> {
-    let inner_cloned = Arc::clone(inner);
-    let handle0 = handle.clone();
+    let inner = Arc::clone(inner);
+    let handle = handle.clone();
     incoming
         .map_err(IncomingError::Io)
         .for_each(move |(stream, addr)| {
-            let handle_cloned = handle0.clone();
-            let inner_cloned = Arc::clone(&inner_cloned);
+            let handle_cloned = handle.clone();
+            let inner_cloned = Arc::clone(&inner);
 
             let header = [0u8; 8];
             tokio_io::io::read_exact(stream, header)

--- a/src/net/peer/connect/demux.rs
+++ b/src/net/peer/connect/demux.rs
@@ -130,7 +130,7 @@ fn handle_incoming_connections<UID: Uid>(
                 .and_then(move |(stream, _header)| {
                     let socket: Socket<HandshakeMessage<UID>> =
                         Socket::wrap_pa(&handle_cloned, stream, addr);
-                    handle_incoming(&handle_cloned, Arc::clone(&inner_cloned), socket)
+                    handle_incoming_socket(&handle_cloned, Arc::clone(&inner_cloned), socket)
                 })
         })
         .log_error(LogLevel::Error, "Failed to accept incoming connections!")
@@ -138,7 +138,8 @@ fn handle_incoming_connections<UID: Uid>(
         .into_boxed()
 }
 
-fn handle_incoming<UID: Uid>(
+/// This methods is called when connection sends valid 8 byte header.
+fn handle_incoming_socket<UID: Uid>(
     handle: &Handle,
     inner: Arc<DemuxInner<UID>>,
     socket: Socket<HandshakeMessage<UID>>,

--- a/src/net/peer/connect/demux.rs
+++ b/src/net/peer/connect/demux.rs
@@ -149,7 +149,7 @@ fn handle_message_by_header<UID: Uid>(
         ECHO_REQ => respond_with_addr(stream, addr),
         CRUST_REQ_HEADER => {
             let socket: Socket<HandshakeMessage<UID>> = Socket::wrap_pa(handle, stream, addr);
-            handle_incoming_socket(handle, Arc::clone(&inner), socket)
+            handle_incoming_socket(handle, inner, socket)
         }
         _ => future::err(IncomingError::UnexpectedMessage).into_boxed(),
     }

--- a/src/net/peer/connect/mod.rs
+++ b/src/net/peer/connect/mod.rs
@@ -36,6 +36,10 @@ use net::peer;
 use net::peer::connect::demux::ConnectMessage;
 use net::peer::connect::handshake_message::{ConnectRequest, HandshakeMessage};
 use priv_prelude::*;
+use tokio_io;
+
+/// Every `Crust` request should start with sending this header.
+const CRUST_REQ_HEADER: [u8; 8] = [b'C', b'R', b'U', b'S', b'T', 0, 0, 0];
 
 pub type RendezvousConnectError = PaRendezvousConnectError<Void, SendError<Bytes>>;
 
@@ -213,7 +217,8 @@ fn connect_directly(
             .into_iter()
             .map(|addr| PaStream::direct_connect(&addr, evloop_handle))
             .collect::<Vec<_>>(),
-    ).map_err(SingleConnectionError::Io)
+    ).and_then(send_request_header)
+        .map_err(SingleConnectionError::Io)
         .into_boxed()
 }
 
@@ -273,6 +278,13 @@ where
             }
             Some(_msg) => Err(SingleConnectionError::UnexpectedMessage),
         })
+        .into_boxed()
+}
+
+/// Sends magic 8 byte string that every connection should be started with.
+fn send_request_header(stream: PaStream) -> IoFuture<PaStream> {
+    tokio_io::io::write_all(stream, CRUST_REQ_HEADER)
+        .map(|(stream, _buf)| stream)
         .into_boxed()
 }
 

--- a/src/net/peer/connect/mod.rs
+++ b/src/net/peer/connect/mod.rs
@@ -39,7 +39,7 @@ use priv_prelude::*;
 use tokio_io;
 
 /// Every `Crust` request should start with sending this header.
-const CRUST_REQ_HEADER: [u8; 8] = [b'C', b'R', b'U', b'S', b'T', 0, 0, 0];
+pub const CRUST_REQ_HEADER: [u8; 8] = [b'C', b'R', b'U', b'S', b'T', 0, 0, 0];
 
 pub type RendezvousConnectError = PaRendezvousConnectError<Void, SendError<Bytes>>;
 

--- a/src/net/peer/connect/mod.rs
+++ b/src/net/peer/connect/mod.rs
@@ -112,6 +112,12 @@ quick_error! {
     }
 }
 
+/// Sends magic 8 byte string that every connection should be started with.
+pub fn send_request_header(stream: PaStream) -> IoFuture<PaStream> {
+    tokio_io::io::write_all(stream, CRUST_REQ_HEADER)
+        .map(|(stream, _buf)| stream)
+        .into_boxed()
+}
 
 /// Perform a rendezvous connect to a peer. Both peers call this simultaneously using
 /// `PubConnectionInfo` they received from the other peer out-of-band.
@@ -278,13 +284,6 @@ where
             }
             Some(_msg) => Err(SingleConnectionError::UnexpectedMessage),
         })
-        .into_boxed()
-}
-
-/// Sends magic 8 byte string that every connection should be started with.
-fn send_request_header(stream: PaStream) -> IoFuture<PaStream> {
-    tokio_io::io::write_all(stream, CRUST_REQ_HEADER)
-        .map(|(stream, _buf)| stream)
         .into_boxed()
 }
 

--- a/src/tests/service_tests.rs
+++ b/src/tests/service_tests.rs
@@ -15,6 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use futures::stream;
 use priv_prelude::*;
 use service::Service;
 use std::time::Duration;
@@ -159,8 +160,6 @@ fn peer_shutdown_closes_remote_peer_too() {
         )
     );
 }
-
-use futures::stream;
 
 #[test]
 fn exchange_data_between_two_peers() {


### PR DESCRIPTION
Make Crust listener to handle rendezvous requests.

This is second attempt. See: https://github.com/maidsafe/crust/pull/895
It aims to have less changes: 8 byte header is sent and received for every new connection.