### PR TITLE
Use p2p instance

### DIFF
--- a/src/net/listener.rs
+++ b/src/net/listener.rs
@@ -104,7 +104,6 @@ impl Listeners {
         let addresses = Arc::clone(&self.addresses);
         let listen_addr = *listen_addr;
 
-        // TODO(povilas): return future with our own error type instead of io::Error?
         PaListener::bind_public(&listen_addr, &handle)
             .map(|(listener, public_addr)| (listener, Some(public_addr)))
             .or_else(move |_| {

--- a/src/net/peer/acceptor.rs
+++ b/src/net/peer/acceptor.rs
@@ -19,6 +19,7 @@ use futures::sync::mpsc::UnboundedReceiver;
 use net::listener::{Listener, Listeners};
 use net::peer::BootstrapAcceptor;
 use net::peer::connect::Demux;
+use p2p::P2p;
 
 use priv_prelude::*;
 
@@ -37,8 +38,8 @@ pub struct Acceptor<UID: Uid> {
 
 impl<UID: Uid> Acceptor<UID> {
     /// Create a new acceptor.
-    pub fn new(handle: &Handle, our_uid: UID, config: ConfigFile) -> Acceptor<UID> {
-        let (listeners, socket_incoming) = Listeners::new(handle);
+    pub fn new(handle: &Handle, our_uid: UID, config: ConfigFile, p2p: P2p) -> Acceptor<UID> {
+        let (listeners, socket_incoming) = Listeners::new(handle, p2p);
         let demux = Demux::new(handle, socket_incoming);
         let handle = handle.clone();
         Acceptor {

--- a/src/net/peer/connect/mod.rs
+++ b/src/net/peer/connect/mod.rs
@@ -35,6 +35,7 @@ use futures::sync::oneshot;
 use net::peer;
 use net::peer::connect::demux::ConnectMessage;
 use net::peer::connect::handshake_message::{ConnectRequest, HandshakeMessage};
+use p2p::P2p;
 use priv_prelude::*;
 use tokio_io;
 
@@ -366,11 +367,12 @@ fn validate_connect_request<UID: Uid>(
 pub fn start_rendezvous_connect(
     handle: &Handle,
     rendezvous_relay: UnboundedBiChannel<Bytes>,
+    p2p: &P2p,
 ) -> oneshot::Receiver<Result<PaStream, RendezvousConnectError>> {
     let (conn_tx, conn_rx) = oneshot::channel();
 
     let connect = {
-        PaStream::rendezvous_connect(rendezvous_relay, handle)
+        PaStream::rendezvous_connect(rendezvous_relay, handle, &p2p)
             .then(move |result| conn_tx.send(result))
             .or_else(|_send_error| Ok(()))
     };

--- a/src/net/protocol_agnostic/listener.rs
+++ b/src/net/protocol_agnostic/listener.rs
@@ -15,7 +15,7 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use p2p;
+use p2p::{self, P2p};
 use priv_prelude::*;
 use tokio_core;
 use tokio_utp;
@@ -73,10 +73,11 @@ impl PaListener {
     pub fn bind_public(
         addr: &PaAddr,
         handle: &Handle,
+        p2p: &P2p,
     ) -> BoxFuture<(PaListener, PaAddr), BindPublicError> {
         match *addr {
             PaAddr::Tcp(ref tcp_addr) => {
-                TcpListener::bind_public(tcp_addr, handle)
+                TcpListener::bind_public(tcp_addr, handle, &p2p)
                     .map_err(BindPublicError::BindTcp)
                     .map(|(listener, public_addr)| {
                         let listener = PaListener::Tcp(listener);
@@ -87,7 +88,7 @@ impl PaListener {
             }
             PaAddr::Utp(utp_addr) => {
                 let handle = handle.clone();
-                UdpSocket::bind_public(&utp_addr, &handle)
+                UdpSocket::bind_public(&utp_addr, &handle, &p2p)
                     .map_err(BindPublicError::BindUdp)
                     .and_then(move |(socket, public_addr)| {
                         let (_, listener) = {

--- a/src/net/protocol_agnostic/stream.rs
+++ b/src/net/protocol_agnostic/stream.rs
@@ -19,6 +19,7 @@ use bincode::{self, Infinite};
 use future_utils::bi_channel;
 use futures::future::Either;
 use futures::sync::mpsc::SendError;
+use p2p::P2p;
 use priv_prelude::*;
 use std::error::Error;
 use std::io::{Read, Write};
@@ -67,6 +68,7 @@ impl PaStream {
     pub fn rendezvous_connect<C>(
         channel: C,
         handle: &Handle,
+        p2p: &P2p,
     ) -> BoxFuture<PaStream, PaRendezvousConnectError<C::Error, C::SinkError>>
     where
         C: Stream<Item = Bytes>,
@@ -123,10 +125,10 @@ impl PaStream {
         let connect = {
             let handle = handle.clone();
             let tcp_connect = {
-                TcpStream::rendezvous_connect(tcp_ch_1, &handle).map(PaStream::Tcp)
+                TcpStream::rendezvous_connect(tcp_ch_1, &handle, &p2p).map(PaStream::Tcp)
             };
             let utp_connect = {
-                UdpSocket::rendezvous_connect(utp_ch_1, &handle)
+                UdpSocket::rendezvous_connect(utp_ch_1, &handle, &p2p)
                     .map_err(UtpRendezvousConnectError::Rendezvous)
                     .and_then(move |(udp_socket, addr)| {
                         let (utp_socket, _utp_listener) = {


### PR DESCRIPTION
Adopts to latest `p2p` changes and uses port mapping instance object instead of singleton one.