### PR TITLE
Fix connection timeouts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,10 @@ path = "examples/connect.rs"
 name = "exchange_data"
 path = "examples/exchange_data.rs"
 
+[[example]]
+name = "chat"
+path = "examples/chat.rs"
+
 [dependencies]
 bytes = { version = "~0.4", features = ["serde"] }
 config_file_handler = "~0.8.0"

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -140,7 +140,7 @@ fn main() {
                         let as_str = unwrap!(serde_json::to_string(&our_pub_info));
                         println!("Our connection info:");
                         println!("{}", as_str);
-                        println!("");
+                        println!();
                         println!(
                             "Copy this info and share it with your connecting partner. Then paste \
                           their info below."

--- a/src/net/peer/connect/mod.rs
+++ b/src/net/peer/connect/mod.rs
@@ -157,7 +157,8 @@ pub fn connect<UID: Uid>(
     );
 
     let direct_incoming = handshake_incoming_connections(our_connect_request, peer_rx, their_id);
-    let all_connections = all_outgoing_connections.select(direct_incoming)
+    let all_connections = all_outgoing_connections
+        .select(direct_incoming)
         .with_timeout(Duration::from_secs(CONNECTIONS_TIMEOUT), handle);
     choose_peer(handle, all_connections, our_info.id, their_id)
         .and_then(move |peer| {

--- a/src/net/peer/connect/mod.rs
+++ b/src/net/peer/connect/mod.rs
@@ -40,6 +40,9 @@ use priv_prelude::*;
 
 pub type RendezvousConnectError = PaRendezvousConnectError<Void, SendError<Bytes>>;
 
+// Seconds after which all connections will timeout.
+const CONNECTIONS_TIMEOUT: u64 = 60;
+
 quick_error! {
     #[derive(Debug)]
     pub enum ConnectError {
@@ -154,7 +157,8 @@ pub fn connect<UID: Uid>(
     );
 
     let direct_incoming = handshake_incoming_connections(our_connect_request, peer_rx, their_id);
-    let all_connections = all_outgoing_connections.select(direct_incoming);
+    let all_connections = all_outgoing_connections.select(direct_incoming)
+        .with_timeout(Duration::from_secs(CONNECTIONS_TIMEOUT), handle);
     choose_peer(handle, all_connections, our_info.id, their_id)
         .and_then(move |peer| {
             let ip = peer.ip().map_err(ConnectError::Peer)?;


### PR DESCRIPTION
Those timeouts were accidentally removed during `p2p` integration. Without them, there are cases when `Crust` just sits there waiting for incoming connections indefinitely.