### PR TITLE
MAID-2497: Fix p2p connections

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -176,9 +176,12 @@ fn read_line() -> BoxFuture<String, Void> {
 }
 
 fn have_a_conversation(service: Service<PeerId>, peer: Peer<PeerId>) -> BoxFuture<(), Void> {
-    let (peer_sink, peer_stream) = peer.split();
+    println!(
+        "You are now connected to '{}'! say hello :)",
+        unwrap!(peer.addr())
+    );
 
-    println!("You are now connected! say hello :)");
+    let (peer_sink, peer_stream) = peer.split();
     let writer = {
         future::loop_fn(peer_sink, |peer_sink| {
             read_line().and_then(|line| {

--- a/src/net/peer/connect/mod.rs
+++ b/src/net/peer/connect/mod.rs
@@ -149,37 +149,17 @@ pub fn connect<UID: Uid>(
         name_hash: name_hash,
         their_pk: our_info.our_pk,
     };
+    let our_id = our_info.id;
+    let our_sk = our_info.our_sk.clone();
 
-    let crypto_ctx = CryptoContext::anonymous_encrypt(their_info.pub_key);
-    let direct_connections = connect_directly(handle, their_info.for_direct, &config);
-    let direct_connections = handshake_outgoing_connections(
-        handle,
-        direct_connections,
-        our_connect_request.clone(),
-        their_id,
-        crypto_ctx,
-        their_info.pub_key,
-        our_info.our_sk.clone(),
-    );
-    let crypto_ctx = CryptoContext::authenticated(their_info.pub_key, our_info.our_sk.clone());
-    let p2p_connection = connect_p2p(our_info.p2p_conn_info, their_info.p2p_conn_info);
-    let p2p_connections = handshake_outgoing_connections(
-        handle,
-        p2p_connection.into_stream(),
-        our_connect_request.clone(),
-        their_id,
-        crypto_ctx,
-        their_info.pub_key,
-        our_info.our_sk.clone(),
-    );
-    let all_outgoing_connections = direct_connections.select(p2p_connections);
-
+    let all_outgoing_connections =
+        attempt_to_connect(handle, &config, &our_connect_request, their_info, our_info);
     let direct_incoming =
-        handshake_incoming_connections(our_connect_request, peer_rx, their_id, our_info.our_sk);
+        handshake_incoming_connections(our_connect_request, peer_rx, their_id, our_sk);
     let all_connections = all_outgoing_connections
         .select(direct_incoming)
         .with_timeout(Duration::from_secs(CONNECTIONS_TIMEOUT), handle);
-    choose_peer(handle, all_connections, our_info.id, their_id)
+    choose_peer(handle, all_connections, our_id, their_id)
         .and_then(move |peer| {
             let ip = peer.ip().map_err(ConnectError::Peer)?;
             if config.is_peer_whitelisted(ip, CrustUser::Node) {
@@ -189,6 +169,44 @@ pub fn connect<UID: Uid>(
             }
         })
         .into_boxed()
+}
+
+/// Initiates both direct and p2p connections.
+fn attempt_to_connect<UID: Uid>(
+    handle: &Handle,
+    config: &ConfigFile,
+    our_connect_request: &ConnectRequest<UID>,
+    their_info: PubConnectionInfo<UID>,
+    our_info: PrivConnectionInfo<UID>,
+) -> BoxStream<(Socket<HandshakeMessage<UID>>, UID), SingleConnectionError> {
+    let direct_connections = {
+        let crypto_ctx = CryptoContext::anonymous_encrypt(their_info.pub_key);
+        let handle = handle.clone();
+        connect_directly(&handle, their_info.for_direct, config).and_then(move |stream| {
+            let peer_addr = stream.peer_addr()?;
+            Ok(Socket::wrap_pa(
+                &handle,
+                stream,
+                peer_addr,
+                crypto_ctx.clone(),
+            ))
+        })
+    };
+    let p2p_connection = {
+        let crypto_ctx = CryptoContext::authenticated(their_info.pub_key, our_info.our_sk.clone());
+        let handle = handle.clone();
+        connect_p2p(our_info.p2p_conn_info, their_info.p2p_conn_info).and_then(move |stream| {
+            let peer_addr = stream.peer_addr()?;
+            Ok(Socket::wrap_pa(&handle, stream, peer_addr, crypto_ctx))
+        })
+    };
+    handshake_outgoing_connections(
+        direct_connections.select(p2p_connection.into_stream()),
+        our_connect_request.clone(),
+        their_info.id,
+        their_info.pub_key,
+        our_info.our_sk,
+    )
 }
 
 /// Takes all pending handshaken connections and chooses the first one successful.
@@ -293,29 +311,17 @@ fn handshake_incoming_connections<UID: Uid>(
 
 /// Executes handshake process for the given connections.
 fn handshake_outgoing_connections<UID: Uid, S>(
-    evloop_handle: &Handle,
     connections: S,
     our_connect_request: ConnectRequest<UID>,
     their_id: UID,
-    crypto_ctx: CryptoContext,
     their_pk: PublicKey,
     our_sk: SecretKey,
 ) -> BoxStream<(Socket<HandshakeMessage<UID>>, UID), SingleConnectionError>
 where
-    S: Stream<Item = PaStream, Error = SingleConnectionError> + 'static,
+    S: Stream<Item = Socket<HandshakeMessage<UID>>, Error = SingleConnectionError> + 'static,
 {
     let our_name_hash = our_connect_request.name_hash;
-    let handle_copy = evloop_handle.clone();
     connections
-        .and_then(move |stream| {
-            let peer_addr = stream.peer_addr()?;
-            Ok(Socket::wrap_pa(
-                &handle_copy,
-                stream,
-                peer_addr,
-                crypto_ctx.clone(),
-            ))
-        })
         .and_then(move |socket| {
             socket
                 .send((0, HandshakeMessage::Connect(our_connect_request.clone())))

--- a/src/tests/service_tests.rs
+++ b/src/tests/service_tests.rs
@@ -23,6 +23,15 @@ use std::time::Duration;
 use tokio_core::reactor::Core;
 use util;
 
+fn service_with_config(event_loop: &mut Core, config: ConfigFile) -> Service<util::UniqueId> {
+    let loop_handle = event_loop.handle();
+    unwrap!(event_loop.run(Service::with_config(
+        &loop_handle,
+        config,
+        util::random_id(),
+    )))
+}
+
 fn service_with_tmp_config(event_loop: &mut Core) -> Service<util::UniqueId> {
     let config = unwrap!(ConfigFile::new_temporary());
     unwrap!(config.write()).listen_addresses = vec![tcp_addr!("0.0.0.0:0"), utp_addr!("0.0.0.0:0")];
@@ -119,6 +128,35 @@ fn connect_works_on_localhost() {
             service2_priv_conn_info,
             service1_pub_conn_info,
         ));
+
+    let (service1_peer, service2_peer) = unwrap!(event_loop.run(connect));
+    assert_eq!(service1_peer.uid(), service2.id());
+    assert_eq!(service2_peer.uid(), service1.id());
+}
+
+// None of the services in this test has listeners, therefore peer-to-peer connections are made.
+#[test]
+fn p2p_connections_on_localhost() {
+    let mut event_loop = unwrap!(Core::new());
+
+    let config = unwrap!(ConfigFile::new_temporary());
+    let service1 = service_with_config(&mut event_loop, config);
+    let service1_priv_conn_info = unwrap!(event_loop.run(service1.prepare_connection_info()));
+    let service1_pub_conn_info = service1_priv_conn_info.to_pub_connection_info();
+
+    let config = unwrap!(ConfigFile::new_temporary());
+    let service2 = service_with_config(&mut event_loop, config);
+    let service2_priv_conn_info = unwrap!(event_loop.run(service2.prepare_connection_info()));
+    let service2_pub_conn_info = service2_priv_conn_info.to_pub_connection_info();
+
+    let connect = service1
+        .connect(service1_priv_conn_info, service2_pub_conn_info)
+        .join(service2.connect(
+            service2_priv_conn_info,
+            service1_pub_conn_info,
+        ))
+        .with_timeout(Duration::from_secs(3), &event_loop.handle())
+        .map(|res_opt| unwrap!(res_opt, "p2p connection timed out"));
 
     let (service1_peer, service2_peer) = unwrap!(event_loop.run(connect));
     assert_eq!(service1_peer.uid(), service2.id());

--- a/src/tests/service_tests.rs
+++ b/src/tests/service_tests.rs
@@ -35,12 +35,7 @@ fn service_with_config(event_loop: &mut Core, config: ConfigFile) -> Service<uti
 fn service_with_tmp_config(event_loop: &mut Core) -> Service<util::UniqueId> {
     let config = unwrap!(ConfigFile::new_temporary());
     unwrap!(config.write()).listen_addresses = vec![tcp_addr!("0.0.0.0:0"), utp_addr!("0.0.0.0:0")];
-    let loop_handle = event_loop.handle();
-    unwrap!(event_loop.run(Service::with_config(
-        &loop_handle,
-        config,
-        util::random_id(),
-    )))
+    service_with_config(event_loop, config)
 }
 
 #[test]


### PR DESCRIPTION
After encryption changes there was some regression introduced: p2p connections wouldn't function anymore. The problem was that initial connect message was sent anonymously encrypted and then the socket would go to authenticated encryption. But it had to wait for anonymously encrypted connect message coming from remote peer first. Hence peers failed to decrypt any future connect messages and connections would fail.

This PR makes p2p connections use authenticated encryption right from the beginning and there's no such problem anymore.