### PR TITLE
MAID-2500: Length delimited echo addr requests

### DIFF
--- a/examples/exchange_data.rs
+++ b/examples/exchange_data.rs
@@ -35,6 +35,8 @@ extern crate serde_derive;
 extern crate rand;
 #[macro_use]
 extern crate rand_derive;
+extern crate void;
+extern crate future_utils;
 
 extern crate crust;
 

--- a/src/net/listener.rs
+++ b/src/net/listener.rs
@@ -22,7 +22,6 @@ use p2p::P2p;
 
 use priv_prelude::*;
 use std::sync::{Arc, Mutex};
-use tokio_io::codec::length_delimited::Framed;
 
 /// A handle for a single listening address. Drop this object to stop listening on this address.
 pub struct Listener {
@@ -190,7 +189,7 @@ fn make_listener(
 }
 
 impl Stream for SocketIncoming {
-    type Item = (Framed<PaStream>, PaAddr);
+    type Item = (FramedPaStream, PaAddr);
     type Error = AcceptError;
 
     fn poll(&mut self) -> Result<Async<Option<Self::Item>>, AcceptError> {

--- a/src/net/listener.rs
+++ b/src/net/listener.rs
@@ -22,6 +22,7 @@ use p2p::P2p;
 
 use priv_prelude::*;
 use std::sync::{Arc, Mutex};
+use tokio_io::codec::length_delimited::Framed;
 
 /// A handle for a single listening address. Drop this object to stop listening on this address.
 pub struct Listener {
@@ -189,7 +190,7 @@ fn make_listener(
 }
 
 impl Stream for SocketIncoming {
-    type Item = (PaStream, PaAddr);
+    type Item = (Framed<PaStream>, PaAddr);
     type Error = AcceptError;
 
     fn poll(&mut self) -> Result<Async<Option<Self::Item>>, AcceptError> {
@@ -589,7 +590,7 @@ mod test {
                         let f = {
                             PaStream::direct_connect(&addr, &handle, &config)
                                 .map_err(|e| panic!(e))
-                                .map(move |stream| {
+                                .map(move |(stream, _peer_addr)| {
                                     Socket::<PaAddr>::wrap_pa(
                                         &handle0,
                                         stream,

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -20,8 +20,9 @@ pub use self::peer::{BootstrapAcceptError, BootstrapAcceptor, BootstrapError, Co
                      ConnectHandshakeError, Demux, ExternalReachability, P2pConnectionInfo, Peer,
                      PeerError, PrivConnectionInfo, PubConnectionInfo, RendezvousConnectError,
                      SingleConnectionError, Uid, bootstrap};
-pub use self::protocol_agnostic::{PaAddr, PaIncoming, PaListener, PaRendezvousConnectError,
-                                  PaStream, UtpRendezvousConnectError, framed_stream};
+pub use self::protocol_agnostic::{FramedPaStream, PaAddr, PaIncoming, PaListener,
+                                  PaRendezvousConnectError, PaStream, UtpRendezvousConnectError,
+                                  framed_stream};
 pub use self::service_discovery::ServiceDiscovery;
 pub use self::socket::{MAX_PAYLOAD_SIZE, Priority, Socket, SocketError};
 

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -21,7 +21,7 @@ pub use self::peer::{BootstrapAcceptError, BootstrapAcceptor, BootstrapError, Co
                      PeerError, PrivConnectionInfo, PubConnectionInfo, RendezvousConnectError,
                      SingleConnectionError, Uid, bootstrap};
 pub use self::protocol_agnostic::{PaAddr, PaIncoming, PaListener, PaRendezvousConnectError,
-                                  PaStream, UtpRendezvousConnectError};
+                                  PaStream, UtpRendezvousConnectError, framed_stream};
 pub use self::service_discovery::ServiceDiscovery;
 pub use self::socket::{MAX_PAYLOAD_SIZE, Priority, Socket, SocketError};
 

--- a/src/net/peer/connect/bootstrap/try_peer.rs
+++ b/src/net/peer/connect/bootstrap/try_peer.rs
@@ -98,7 +98,7 @@ pub fn try_peer<UID: Uid>(
     let handle1 = handle.clone();
     let addr = *addr;
     PaStream::direct_connect(&addr, handle, config)
-        .map(move |stream| {
+        .map(move |(stream, _peer_addr)| {
             Socket::wrap_pa(
                 &handle0,
                 stream,

--- a/src/net/peer/connect/mod.rs
+++ b/src/net/peer/connect/mod.rs
@@ -21,7 +21,6 @@ pub use self::connection_info::{P2pConnectionInfo, PrivConnectionInfo, PubConnec
 pub use self::demux::Demux;
 pub use self::ext_reachability::ExternalReachability;
 pub use self::handshake_message::{BootstrapDenyReason, BootstrapRequest};
-use tokio_io::codec::length_delimited::Framed;
 
 mod bootstrap;
 mod connection_info;
@@ -278,7 +277,7 @@ fn connect_directly(
     evloop_handle: &Handle,
     addrs: Vec<PaAddr>,
     config: &ConfigFile,
-) -> BoxStream<(Framed<PaStream>, PaAddr), SingleConnectionError> {
+) -> BoxStream<(FramedPaStream, PaAddr), SingleConnectionError> {
     stream::futures_unordered(
         addrs
             .into_iter()

--- a/src/net/protocol_agnostic/addr.rs
+++ b/src/net/protocol_agnostic/addr.rs
@@ -61,6 +61,15 @@ impl PaAddr {
         }
     }
 
+    /// Returns socket address without protocol information.
+    #[cfg(test)]
+    pub fn inner(&self) -> SocketAddr {
+        match *self {
+            PaAddr::Tcp(ref addr) |
+            PaAddr::Utp(ref addr) => *addr,
+        }
+    }
+
     /// Returns all local addresses, if socket address is unspecified - '0.0.0.0'.
     /// Otherwise a list with only current address is returned.
     pub fn expand_local_unspecified(&self) -> io::Result<Vec<PaAddr>> {

--- a/src/net/protocol_agnostic/mod.rs
+++ b/src/net/protocol_agnostic/mod.rs
@@ -17,7 +17,7 @@
 
 pub use self::addr::PaAddr;
 pub use self::listener::{AcceptError, PaIncoming, PaListener};
-pub use self::stream::{PaRendezvousConnectError, PaRendezvousMsg, PaStream,
+pub use self::stream::{FramedPaStream, PaRendezvousConnectError, PaRendezvousMsg, PaStream,
                        UtpRendezvousConnectError, framed_stream};
 
 mod stream;

--- a/src/net/protocol_agnostic/mod.rs
+++ b/src/net/protocol_agnostic/mod.rs
@@ -18,7 +18,7 @@
 pub use self::addr::PaAddr;
 pub use self::listener::{AcceptError, PaIncoming, PaListener};
 pub use self::stream::{PaRendezvousConnectError, PaRendezvousMsg, PaStream,
-                       UtpRendezvousConnectError};
+                       UtpRendezvousConnectError, framed_stream};
 
 mod stream;
 mod listener;

--- a/src/net/protocol_agnostic/stream.rs
+++ b/src/net/protocol_agnostic/stream.rs
@@ -44,6 +44,9 @@ where
         .new_framed(stream)
 }
 
+/// Protocol agnostic stream that yields length delimited frames of `BytesMut`.
+pub type FramedPaStream = Framed<PaStream, BytesMut>;
+
 #[derive(Debug)]
 pub enum PaStream {
     Tcp(TcpStream),

--- a/src/priv_prelude.rs
+++ b/src/priv_prelude.rs
@@ -30,7 +30,7 @@ pub use net::{BootstrapAcceptError, BootstrapError, ConnectError, ConnectHandsha
               ExternalReachability, P2pConnectionInfo, PaRendezvousConnectError, Peer, PeerError,
               Priority, PrivConnectionInfo, PubConnectionInfo, RendezvousConnectError,
               SingleConnectionError, Socket, SocketError, UtpRendezvousConnectError};
-pub use net::{PaAddr, PaIncoming, PaListener, PaStream, framed_stream};
+pub use net::{FramedPaStream, PaAddr, PaIncoming, PaListener, PaStream, framed_stream};
 pub use net::Uid;
 pub use net2::TcpBuilder;
 pub use p2p::{P2p, SocketAddrExt, TcpListenerExt, TcpStreamExt, UdpSocketExt};

--- a/src/priv_prelude.rs
+++ b/src/priv_prelude.rs
@@ -30,7 +30,7 @@ pub use net::{BootstrapAcceptError, BootstrapError, ConnectError, ConnectHandsha
               ExternalReachability, P2pConnectionInfo, PaRendezvousConnectError, Peer, PeerError,
               Priority, PrivConnectionInfo, PubConnectionInfo, RendezvousConnectError,
               SingleConnectionError, Socket, SocketError, UtpRendezvousConnectError};
-pub use net::{PaAddr, PaIncoming, PaListener, PaStream};
+pub use net::{PaAddr, PaIncoming, PaListener, PaStream, framed_stream};
 pub use net::Uid;
 pub use net2::TcpBuilder;
 pub use p2p::{P2p, SocketAddrExt, TcpListenerExt, TcpStreamExt, UdpSocketExt};


### PR DESCRIPTION
These changes are in tandem with https://github.com/ustulation/p2p/pull/52

Basically it makes Crust TCP listener expect length delimited messages.