### PR TITLE
MAID-2499: Encrypt service discovery

### DIFF
--- a/src/compat/service.rs
+++ b/src/compat/service.rs
@@ -442,8 +442,9 @@ impl<UID: Uid> Service<UID> {
                 let sd_port = config.read().service_discovery_port.unwrap_or(
                     ::service::SERVICE_DISCOVERY_DEFAULT_PORT,
                 );
+                let our_pk = state.service.public_key();
                 let f = {
-                    service_discovery::discover::<Vec<SocketAddr>>(handle, sd_port)
+                    service_discovery::discover::<Vec<SocketAddr>>(handle, sd_port, our_pk)
                         .into_future()
                         .map(|s| s.infallible())
                         .flatten_stream()

--- a/src/compat/service.rs
+++ b/src/compat/service.rs
@@ -443,8 +443,9 @@ impl<UID: Uid> Service<UID> {
                     ::service::SERVICE_DISCOVERY_DEFAULT_PORT,
                 );
                 let our_pk = state.service.public_key();
+                let our_sk = state.service.private_key();
                 let f = {
-                    service_discovery::discover::<Vec<SocketAddr>>(handle, sd_port, our_pk)
+                    service_discovery::discover::<Vec<SocketAddr>>(handle, sd_port, our_pk, our_sk)
                         .into_future()
                         .map(|s| s.infallible())
                         .flatten_stream()

--- a/src/config.rs
+++ b/src/config.rs
@@ -283,7 +283,7 @@ impl ConfigWrapper {
 }
 
 /// Information necessary to connect to peer.
-#[derive(PartialEq, Eq, Clone, Debug, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Hash, Clone, Debug, Serialize, Deserialize)]
 pub struct PeerInfo {
     /// Peer public address.
     pub addr: PaAddr,

--- a/src/net/peer/connect/bootstrap/mod.rs
+++ b/src/net/peer/connect/bootstrap/mod.rs
@@ -67,6 +67,7 @@ pub fn bootstrap<UID: Uid>(
     use_service_discovery: bool,
     config: &ConfigFile,
     our_sk: SecretKey,
+    our_pk: PublicKey,
 ) -> BoxFuture<Peer<UID>, BootstrapError> {
     let config = config.clone();
     let handle = handle.clone();
@@ -75,7 +76,7 @@ pub fn bootstrap<UID: Uid>(
             let sd_port = config.read().service_discovery_port.unwrap_or(
                 service::SERVICE_DISCOVERY_DEFAULT_PORT,
             );
-            service_discovery::discover::<Vec<PeerInfo>>(&handle, sd_port)
+            service_discovery::discover::<Vec<PeerInfo>>(&handle, sd_port, our_pk)
                 .map_err(BootstrapError::ServiceDiscovery)?
                 .infallible::<(PaAddr, TryPeerError)>()
                 .map(|(_, v)| stream::iter_ok(v))

--- a/src/net/peer/connect/bootstrap/mod.rs
+++ b/src/net/peer/connect/bootstrap/mod.rs
@@ -76,7 +76,7 @@ pub fn bootstrap<UID: Uid>(
             let sd_port = config.read().service_discovery_port.unwrap_or(
                 service::SERVICE_DISCOVERY_DEFAULT_PORT,
             );
-            service_discovery::discover::<Vec<PeerInfo>>(&handle, sd_port, our_pk)
+            service_discovery::discover::<Vec<PeerInfo>>(&handle, sd_port, our_pk, our_sk.clone())
                 .map_err(BootstrapError::ServiceDiscovery)?
                 .infallible::<(PaAddr, TryPeerError)>()
                 .map(|(_, v)| stream::iter_ok(v))

--- a/src/net/peer/connect/bootstrap/mod.rs
+++ b/src/net/peer/connect/bootstrap/mod.rs
@@ -75,13 +75,11 @@ pub fn bootstrap<UID: Uid>(
             let sd_port = config.read().service_discovery_port.unwrap_or(
                 service::SERVICE_DISCOVERY_DEFAULT_PORT,
             );
-            service_discovery::discover::<Vec<PaAddr>>(&handle, sd_port)
+            service_discovery::discover::<Vec<PeerInfo>>(&handle, sd_port)
                 .map_err(BootstrapError::ServiceDiscovery)?
                 .infallible::<(PaAddr, TryPeerError)>()
                 .map(|(_, v)| stream::iter_ok(v))
                 .flatten()
-                // TODO(povilas): remove this when service discovery returns peer public key
-                .map(PeerInfo::with_rand_key)
                 .into_boxed()
         } else {
             future::empty().into_stream().into_boxed()

--- a/src/net/service_discovery/discover.rs
+++ b/src/net/service_discovery/discover.rs
@@ -66,6 +66,11 @@ pub struct Discover<T> {
     _ph: PhantomData<T>,
 }
 
+// The only large size difference between variance is because of `Invalid` variant.
+// This variant is not really used, hence it makes sense to disable this lint.
+//#[cfg_attr(feature = "clippy", allow(large_enum_variant))]
+#[allow(unknown_lints)]
+#[allow(large_enum_variant)]
 enum DiscoverState {
     Reading { reading: StreamFuture<UdpFramed<SerdeUdpCodec<DiscoveryMsg>>>, },
     Writing { writing: sink::Send<UdpFramed<SerdeUdpCodec<DiscoveryMsg>>>, },

--- a/src/net/service_discovery/discover.rs
+++ b/src/net/service_discovery/discover.rs
@@ -15,11 +15,13 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+
 use futures::{Async, Future, Sink, Stream};
 use futures::sink;
 use futures::stream::StreamFuture;
 
 use net::service_discovery::msg::DiscoveryMsg;
+use priv_prelude::*;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::{io, mem};
@@ -29,7 +31,7 @@ use tokio_core::reactor::Handle;
 use util::SerdeUdpCodec;
 use void::Void;
 
-pub fn discover<T>(handle: &Handle, port: u16) -> io::Result<Discover<T>>
+pub fn discover<T>(handle: &Handle, port: u16, our_pk: PublicKey) -> io::Result<Discover<T>>
 where
     T: Serialize + DeserializeOwned + Clone + 'static,
 {
@@ -39,7 +41,7 @@ where
     socket.set_broadcast(true)?;
     let framed = socket.framed(SerdeUdpCodec::new());
 
-    let request = DiscoveryMsg::Request;
+    let request = DiscoveryMsg::Request(our_pk);
     let broadcast_addr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(255, 255, 255, 255), port));
     let writing = framed.send((broadcast_addr, request));
 

--- a/src/net/service_discovery/msg.rs
+++ b/src/net/service_discovery/msg.rs
@@ -18,8 +18,9 @@
 use priv_prelude::*;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum DiscoveryMsg<T> {
+pub enum DiscoveryMsg {
     /// Request has sender's public key which should be used to encrypt response.
     Request(PublicKey),
-    Response(T),
+    /// Response comes serialized and encrypted.
+    Response(BytesMut),
 }

--- a/src/net/service_discovery/msg.rs
+++ b/src/net/service_discovery/msg.rs
@@ -15,8 +15,11 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+use priv_prelude::*;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum DiscoveryMsg<T> {
-    Request,
+    /// Request has sender's public key which should be used to encrypt response.
+    Request(PublicKey),
     Response(T),
 }

--- a/src/net/service_discovery/server.rs
+++ b/src/net/service_discovery/server.rs
@@ -117,7 +117,7 @@ where
                         unwrap!(reading.poll().map_err(|(e, _)| e))
                     {
                         match res {
-                            Some((addr, Ok(DiscoveryMsg::Request))) => {
+                            Some((addr, Ok(DiscoveryMsg::Request(_)))) => {
                                 let response = DiscoveryMsg::Response(self.data.clone());
                                 let writing = framed.send((addr, response));
                                 state = ServerTaskState::Writing { writing };

--- a/src/net/service_discovery/server.rs
+++ b/src/net/service_discovery/server.rs
@@ -15,13 +15,16 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
+
 use future_utils::FutureExt;
 use futures::{Async, Future, Sink, Stream};
 use futures::sink;
 use futures::stream::StreamFuture;
 use futures::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 
+use maidsafe_utilities::serialisation::SerialisationError;
 use net::service_discovery::msg::DiscoveryMsg;
+use priv_prelude::*;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::{io, mem};
@@ -45,15 +48,12 @@ where
 {
     data_rx: UnboundedReceiver<T>,
     data: T,
-    state: ServerTaskState<T>,
+    state: ServerTaskState,
 }
 
-enum ServerTaskState<T>
-where
-    T: Serialize + DeserializeOwned + Clone + 'static,
-{
-    Reading { reading: StreamFuture<UdpFramed<SerdeUdpCodec<DiscoveryMsg<T>>>>, },
-    Writing { writing: sink::Send<UdpFramed<SerdeUdpCodec<DiscoveryMsg<T>>>>, },
+enum ServerTaskState {
+    Reading { reading: StreamFuture<UdpFramed<SerdeUdpCodec<DiscoveryMsg>>>, },
+    Writing { writing: sink::Send<UdpFramed<SerdeUdpCodec<DiscoveryMsg>>>, },
     Invalid,
 }
 
@@ -93,6 +93,40 @@ where
     }
 }
 
+impl<T> ServerTask<T>
+where
+    T: Serialize + DeserializeOwned + Clone + 'static,
+{
+    /// Handles service discovery request.
+    /// Returns new server state: either reading or writing.  In case of any errors server remains
+    /// in reading state.
+    fn handle_request(
+        &self,
+        request: Option<(SocketAddr, Result<DiscoveryMsg, SerialisationError>)>,
+        framed: UdpFramed<SerdeUdpCodec<DiscoveryMsg>>,
+    ) -> ServerTaskState {
+        match request {
+            Some((addr, Ok(DiscoveryMsg::Request(their_pk)))) => {
+                let crypto_ctx = CryptoContext::anonymous_encrypt(their_pk);
+                match crypto_ctx.encrypt(&self.data) {
+                    Ok(response) => {
+                        let response = DiscoveryMsg::Response(response);
+                        let writing = framed.send((addr, response));
+                        return ServerTaskState::Writing { writing };
+                    }
+                    Err(e) => warn!("Failed to encrypt service discovery response: {}", e),
+                }
+            }
+            Some((_, Ok(..))) => (),
+            Some((addr, Err(e))) => {
+                warn!("Error deserialising message from {}: {}", addr, e);
+            }
+            None => unreachable!(),
+        }
+        ServerTaskState::Reading { reading: framed.into_future() }
+    }
+}
+
 impl<T> Future for ServerTask<T>
 where
     T: Serialize + DeserializeOwned + Clone + 'static,
@@ -113,23 +147,10 @@ where
         loop {
             match state {
                 ServerTaskState::Reading { mut reading } => {
-                    if let Async::Ready((res, framed)) =
+                    if let Async::Ready((request, framed)) =
                         unwrap!(reading.poll().map_err(|(e, _)| e))
                     {
-                        match res {
-                            Some((addr, Ok(DiscoveryMsg::Request(_)))) => {
-                                let response = DiscoveryMsg::Response(self.data.clone());
-                                let writing = framed.send((addr, response));
-                                state = ServerTaskState::Writing { writing };
-                                continue;
-                            }
-                            Some((_, Ok(..))) => (),
-                            Some((addr, Err(e))) => {
-                                warn!("Error deserialising message from {}: {}", addr, e);
-                            }
-                            None => unreachable!(),
-                        }
-                        state = ServerTaskState::Reading { reading: framed.into_future() };
+                        state = self.handle_request(request, framed);
                         continue;
                     } else {
                         state = ServerTaskState::Reading { reading };

--- a/src/net/service_discovery/server.rs
+++ b/src/net/service_discovery/server.rs
@@ -51,6 +51,10 @@ where
     state: ServerTaskState,
 }
 
+// The only large size difference between variance is because of `Invalid` variant.
+// This variant is not really used, hence it makes sense to disable this lint.
+#[allow(unknown_lints)]
+#[allow(large_enum_variant)]
 enum ServerTaskState {
     Reading { reading: StreamFuture<UdpFramed<SerdeUdpCodec<DiscoveryMsg>>>, },
     Writing { writing: sink::Send<UdpFramed<SerdeUdpCodec<DiscoveryMsg>>>, },

--- a/src/net/service_discovery/test.rs
+++ b/src/net/service_discovery/test.rs
@@ -16,12 +16,14 @@
 // relating to use of the SAFE Network Software.
 
 use super::*;
+use config::PeerInfo;
 use env_logger;
 use future_utils::StreamExt;
 use futures::{Future, Stream, future, stream};
 use futures::sync::mpsc;
 use net::service_discovery::server::Server;
 use priv_prelude::*;
+use rust_sodium::crypto::box_::gen_keypair;
 use std::time::Duration;
 use tokio_core::reactor::Core;
 
@@ -62,6 +64,10 @@ fn test() {
     let _servers = unwrap!(res);
 }
 
+fn peer_addrs(peers: &HashSet<PeerInfo>) -> HashSet<PaAddr> {
+    peers.iter().map(|peer| peer.addr).collect()
+}
+
 #[test]
 fn service_discovery() {
     let _logger = env_logger::init();
@@ -73,11 +79,18 @@ fn service_discovery() {
     unwrap!(config.write()).service_discovery_port = Some(0);
     let (tx, rx) = mpsc::unbounded();
 
-    let sd = unwrap!(ServiceDiscovery::new(&handle, &config, hashset!{}, rx));
+    let (our_pk, _our_sk) = gen_keypair();
+    let sd = unwrap!(ServiceDiscovery::new(
+        &handle,
+        &config,
+        &hashset!{},
+        rx,
+        our_pk,
+    ));
     let port = sd.port();
 
     let f = {
-        unwrap!(discover::<HashSet<SocketAddr>>(&handle, port))
+        unwrap!(discover::<HashSet<PeerInfo>>(&handle, port))
             .with_timeout(Duration::from_millis(200), &handle)
             .collect()
             .and_then(move |v| {
@@ -93,20 +106,20 @@ fn service_discovery() {
                 let handle0 = handle.clone();
 
                 Timeout::new(Duration::from_millis(100), &handle)
-            .map_err(|e| panic!(e))
-            .map(move |()| {
-                unwrap!(discover::<HashSet<PaAddr>>(&handle0, port))
-            })
-            .flatten_stream()
-            .until({
-                Timeout::new(Duration::from_millis(200), &handle)
-                .map_err(|e| panic!(e))
-            })
-            .collect()
-            .map(move |v| {
-                assert!(v.into_iter().any(|(_, addrs)| addrs == some_addrs));
-                drop(sd);
-            })
+                    .map_err(|e| panic!(e))
+                    .map(move |()| {
+                        unwrap!(discover::<HashSet<PeerInfo>>(&handle0, port))
+                    })
+                    .flatten_stream()
+                    .until({
+                        Timeout::new(Duration::from_millis(200), &handle)
+                        .map_err(|e| panic!(e))
+                    })
+                    .collect()
+                    .map(move |v| {
+                        assert!(v.into_iter().any(|(_, peers)| peer_addrs(&peers) == some_addrs));
+                        drop(sd);
+                    })
             })
     };
     let res = core.run(f);

--- a/src/net/service_discovery/test.rs
+++ b/src/net/service_discovery/test.rs
@@ -46,7 +46,8 @@ fn test() {
         let mut futures = Vec::new();
         for i in 0..num_servers {
             for _ in 0..num_discovers {
-                let discover = unwrap!(discover::<u16>(&handle, starting_port + i))
+                let (our_pk, _our_sk) = gen_keypair();
+                let discover = unwrap!(discover::<u16>(&handle, starting_port + i, our_pk))
                     .with_timeout(Duration::from_secs(1), &handle)
                     .collect()
                     .and_then(move |v| {
@@ -90,7 +91,8 @@ fn service_discovery() {
     let port = sd.port();
 
     let f = {
-        unwrap!(discover::<HashSet<PeerInfo>>(&handle, port))
+        let (our_pk, _our_sk) = gen_keypair();
+        unwrap!(discover::<HashSet<PeerInfo>>(&handle, port, our_pk))
             .with_timeout(Duration::from_millis(200), &handle)
             .collect()
             .and_then(move |v| {
@@ -108,7 +110,7 @@ fn service_discovery() {
                 Timeout::new(Duration::from_millis(100), &handle)
                     .map_err(|e| panic!(e))
                     .map(move |()| {
-                        unwrap!(discover::<HashSet<PeerInfo>>(&handle0, port))
+                        unwrap!(discover::<HashSet<PeerInfo>>(&handle0, port, our_pk))
                     })
                     .flatten_stream()
                     .until({

--- a/src/service.rs
+++ b/src/service.rs
@@ -210,7 +210,13 @@ impl<UID: Uid> Service<UID> {
     /// the local network (via udp broadcast).
     pub fn start_service_discovery(&self) -> io::Result<ServiceDiscovery> {
         let (current_addrs, addrs_rx) = self.listeners.addresses();
-        ServiceDiscovery::new(&self.handle, &self.config, current_addrs, addrs_rx)
+        ServiceDiscovery::new(
+            &self.handle,
+            &self.config,
+            &current_addrs,
+            addrs_rx,
+            self.our_pk,
+        )
     }
 
     /// Return the set of all addresses that we are currently listening for incoming connections

--- a/src/service.rs
+++ b/src/service.rs
@@ -141,6 +141,7 @@ impl<UID: Uid> Service<UID> {
             use_service_discovery,
             &self.config,
             self.our_sk.clone(),
+            self.our_pk,
         )
     }
 
@@ -267,7 +268,6 @@ impl<UID: Uid> Service<UID> {
     }
 
     /// Returns service public key.
-    #[cfg(test)]
     pub fn public_key(&self) -> PublicKey {
         self.our_pk
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -241,6 +241,16 @@ impl<UID: Uid> Service<UID> {
         &self.p2p
     }
 
+    /// Returns service public key.
+    pub fn public_key(&self) -> PublicKey {
+        self.our_pk
+    }
+
+    /// Returns service private key.
+    pub fn private_key(&self) -> SecretKey {
+        self.our_sk.clone()
+    }
+
     /// Constructs private connection info with p2p info returned from `p2p` crate.
     /// p2p info is used for rendezvous connections - hole punching.
     fn with_p2p_connection_info(
@@ -265,11 +275,6 @@ impl<UID: Uid> Service<UID> {
             .map_err(|(e, _stream)| e)
             .infallible()
             .into_boxed()
-    }
-
-    /// Returns service public key.
-    pub fn public_key(&self) -> PublicKey {
-        self.our_pk
     }
 }
 

--- a/src/tests/compat_api.rs
+++ b/src/tests/compat_api.rs
@@ -280,7 +280,6 @@ fn bootstrap_using_hard_coded_contacts() {
 }
 
 #[test]
-#[ignore] // TODO(povilas): change this when service discovery is restored
 fn bootstrap_using_service_discovery() {
     let _ = env_logger::init();
 


### PR DESCRIPTION
Changes to service discovery:
1. SD server responds with our addresses and our public key used to connect to us directly
2. SD client inserts our public key into request and send it unencrypted
3. SD server encrypts responses

Also adds service test that checks, if bootstrap via service discovery works.
