### PR TITLE
MAID-2502: implement bootstrap cache

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -334,7 +334,7 @@ pub struct ConfigSettings {
     /// Port for service discovery on local network
     pub service_discovery_port: Option<u16>,
     /// File for bootstrap cache
-    pub bootstrap_cache_name: Option<PathBuf>,
+    pub bootstrap_cache_name: Option<OsString>,
     /// Whitelisted nodes who are allowed to bootstrap off us or to connect to us
     pub whitelisted_node_ips: Option<HashSet<IpAddr>>,
     /// Whitelisted clients who are allowed to bootstrap off us

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,5 +64,12 @@ quick_error! {
             description("error starting listener")
             display("error starting listener, {}", e)
         }
+        /// Error reading bootstrap cache.
+        ReadBootstrapCache(e: BootstrapCacheError)  {
+            description("Error reading bootstrap cache")
+            display("Error reading bootstrap cache: {}", e)
+            cause(e)
+            from()
+        }
     }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -16,10 +16,11 @@
 // relating to use of the SAFE Network Software.
 
 pub use self::listener::{Acceptor, Listener};
-pub use self::peer::{BootstrapAcceptError, BootstrapAcceptor, BootstrapError, ConnectError,
-                     ConnectHandshakeError, Demux, ExternalReachability, P2pConnectionInfo, Peer,
-                     PeerError, PrivConnectionInfo, PubConnectionInfo, RendezvousConnectError,
-                     SingleConnectionError, Uid, bootstrap};
+pub use self::peer::{BootstrapAcceptError, BootstrapAcceptor, BootstrapCache, BootstrapCacheError,
+                     BootstrapError, ConnectError, ConnectHandshakeError, Demux,
+                     ExternalReachability, P2pConnectionInfo, Peer, PeerError, PrivConnectionInfo,
+                     PubConnectionInfo, RendezvousConnectError, SingleConnectionError, Uid,
+                     bootstrap};
 pub use self::protocol_agnostic::{FramedPaStream, PaAddr, PaIncoming, PaListener,
                                   PaRendezvousConnectError, PaStream, UtpRendezvousConnectError,
                                   framed_stream};

--- a/src/net/peer/connect/bootstrap/mod.rs
+++ b/src/net/peer/connect/bootstrap/mod.rs
@@ -169,7 +169,7 @@ mod tests {
             let config = unwrap!(ConfigFile::new_temporary());
             unwrap!(config.write()).hard_coded_contacts =
                 vec![PeerInfo::with_rand_key(tcp_addr!("1.2.3.4:4000"))];
-            let cache = unwrap!(Cache::new(Some(bootstrap_cache_tmp_file().as_path())));
+            let cache = unwrap!(Cache::new(Some(&bootstrap_cache_tmp_file())));
             cache.put(&PeerInfo::with_rand_key(tcp_addr!("1.2.3.5:5000")));
 
             let peers: Vec<PaAddr> = unwrap!(bootstrap_peers(&config, &cache))

--- a/src/net/peer/connect/bootstrap/mod.rs
+++ b/src/net/peer/connect/bootstrap/mod.rs
@@ -136,8 +136,9 @@ pub fn bootstrap<UID: Uid>(
 fn bootstrap_peers(config: &ConfigFile) -> Result<Vec<PeerInfo>, BootstrapError> {
     let config = config.read();
     let cache = Cache::new(config.bootstrap_cache_name.as_ref().map(|p| p.as_ref()))?;
+    cache.read_file();
     let mut peers = Vec::new();
-    peers.extend(cache.read_file());
+    peers.extend(cache.peers());
     peers.extend(config.hard_coded_contacts.clone());
     Ok(peers)
 }

--- a/src/net/peer/connect/bootstrap/mod.rs
+++ b/src/net/peer/connect/bootstrap/mod.rs
@@ -60,9 +60,9 @@ pub fn bootstrap<UID: Uid>(
     use_service_discovery: bool,
     config: &ConfigFile,
     our_sk: SecretKey,
-    our_pk: PublicKey,
     cache: &Cache,
 ) -> BoxFuture<Peer<UID>, BootstrapError> {
+    let our_pk = request.their_pk;
     let config = config.clone();
     let handle = handle.clone();
     let cache = cache.clone();

--- a/src/net/peer/connect/bootstrap/mod.rs
+++ b/src/net/peer/connect/bootstrap/mod.rs
@@ -135,7 +135,7 @@ pub fn bootstrap<UID: Uid>(
 /// Collects bootstrap peers from cache and config.
 fn bootstrap_peers(config: &ConfigFile) -> Result<Vec<PeerInfo>, BootstrapError> {
     let config = config.read();
-    let mut cache = Cache::new(config.bootstrap_cache_name.as_ref().map(|p| p.as_ref()))?;
+    let cache = Cache::new(config.bootstrap_cache_name.as_ref().map(|p| p.as_ref()))?;
     let mut peers = Vec::new();
     peers.extend(cache.read_file());
     peers.extend(config.hard_coded_contacts.clone());

--- a/src/net/peer/connect/mod.rs
+++ b/src/net/peer/connect/mod.rs
@@ -15,7 +15,8 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-pub use self::bootstrap::{BootstrapError, ConnectHandshakeError, bootstrap};
+pub use self::bootstrap::{BootstrapError, Cache as BootstrapCache,
+                          CacheError as BootstrapCacheError, ConnectHandshakeError, bootstrap};
 pub use self::bootstrap_acceptor::{BootstrapAcceptError, BootstrapAcceptor};
 pub use self::connection_info::{P2pConnectionInfo, PrivConnectionInfo, PubConnectionInfo};
 pub use self::demux::Demux;

--- a/src/net/peer/mod.rs
+++ b/src/net/peer/mod.rs
@@ -15,11 +15,11 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-pub use self::connect::{BootstrapAcceptError, BootstrapAcceptor, BootstrapError, BootstrapRequest,
-                        ConnectError, ConnectHandshakeError, Demux, ExternalReachability,
-                        P2pConnectionInfo, PrivConnectionInfo, PubConnectionInfo,
-                        RendezvousConnectError, SingleConnectionError, bootstrap,
-                        start_rendezvous_connect};
+pub use self::connect::{BootstrapAcceptError, BootstrapAcceptor, BootstrapCache,
+                        BootstrapCacheError, BootstrapError, BootstrapRequest, ConnectError,
+                        ConnectHandshakeError, Demux, ExternalReachability, P2pConnectionInfo,
+                        PrivConnectionInfo, PubConnectionInfo, RendezvousConnectError,
+                        SingleConnectionError, bootstrap, start_rendezvous_connect};
 pub use self::peer_message::PeerMessage;
 pub use self::uid::Uid;
 use std::fmt;

--- a/src/net/service_discovery/test.rs
+++ b/src/net/service_discovery/test.rs
@@ -48,7 +48,7 @@ fn multiple_server_instances_in_parallel() {
             for _ in 0..num_discovers {
                 let (our_pk, our_sk) = gen_keypair();
                 let discover = unwrap!(discover::<u16>(&handle, starting_port + i, our_pk, our_sk))
-                    .with_timeout(Duration::from_secs(1), &handle)
+                    .with_timeout(Duration::from_secs(2), &handle)
                     .collect()
                     .and_then(move |v| {
                         assert_eq!(v.into_iter().map(|(_, p)| p).collect::<Vec<_>>(), &[i]);
@@ -97,7 +97,7 @@ fn service_discovery() {
             port,
             our_pk,
             our_sk.clone(),
-        )).with_timeout(Duration::from_millis(200), &handle)
+        )).with_timeout(Duration::from_secs(2), &handle)
             .collect()
             .and_then(move |v| {
                 assert!(v.into_iter().any(|(_, addrs)| addrs == hashset!{}));

--- a/src/priv_prelude.rs
+++ b/src/priv_prelude.rs
@@ -40,6 +40,7 @@ pub use serde::Serialize;
 pub use serde::de::DeserializeOwned;
 pub use std::{fmt, io, mem};
 pub use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+pub use std::ffi::{OsStr, OsString};
 pub use std::marker::PhantomData;
 pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 pub use std::net::{SocketAddr, SocketAddrV4, SocketAddrV6};

--- a/src/priv_prelude.rs
+++ b/src/priv_prelude.rs
@@ -25,10 +25,11 @@ pub use config::ConfigFile;
 pub use error::CrustError;
 pub use future_utils::{BoxFuture, BoxStream, FutureExt, IoFuture, IoStream, StreamExt, Timeout};
 pub use futures::{Async, AsyncSink, Future, IntoFuture, Sink, Stream, future, stream};
-pub use net::{BootstrapAcceptError, BootstrapError, ConnectError, ConnectHandshakeError,
-              ExternalReachability, P2pConnectionInfo, PaRendezvousConnectError, Peer, PeerError,
-              Priority, PrivConnectionInfo, PubConnectionInfo, RendezvousConnectError,
-              SingleConnectionError, Socket, SocketError, UtpRendezvousConnectError};
+pub use net::{BootstrapAcceptError, BootstrapCache, BootstrapCacheError, BootstrapError,
+              ConnectError, ConnectHandshakeError, ExternalReachability, P2pConnectionInfo,
+              PaRendezvousConnectError, Peer, PeerError, Priority, PrivConnectionInfo,
+              PubConnectionInfo, RendezvousConnectError, SingleConnectionError, Socket,
+              SocketError, UtpRendezvousConnectError};
 pub use net::{FramedPaStream, PaAddr, PaIncoming, PaListener, PaStream, framed_stream};
 pub use net::{MAX_PAYLOAD_SIZE, Uid};
 pub use net2::TcpBuilder;

--- a/src/service.rs
+++ b/src/service.rs
@@ -77,10 +77,11 @@ impl<UID: Uid> Service<UID> {
         let (our_pk, our_sk) = gen_keypair();
         let anon_decrypt_ctx = CryptoContext::anonymous_decrypt(our_pk, our_sk.clone());
 
+        let bootstrap_cache_name = config.read().bootstrap_cache_name.clone();
         let bootstrap_cache = try_bfut!(
-            BootstrapCache::new(config.read().bootstrap_cache_name.as_ref().map(
-                |p| p.as_ref(),
-            )).map_err(CrustError::ReadBootstrapCache)
+            BootstrapCache::new(
+                bootstrap_cache_name.as_ref().map(|s| s.as_os_str()),
+            ).map_err(CrustError::ReadBootstrapCache)
         );
         bootstrap_cache.read_file();
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -151,7 +151,6 @@ impl<UID: Uid> Service<UID> {
             use_service_discovery,
             &self.config,
             self.our_sk.clone(),
-            self.our_pk,
             &self.bootstrap_cache,
         )
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -77,20 +77,20 @@ impl<UID: Uid> Service<UID> {
         let (our_pk, our_sk) = gen_keypair();
         let anon_decrypt_ctx = CryptoContext::anonymous_decrypt(our_pk, our_sk.clone());
 
-        let (listeners, socket_incoming) = Acceptor::new(
-            &handle,
-            p2p.clone(),
-            anon_decrypt_ctx.clone(),
-            our_sk.clone(),
-        );
-        let demux = Demux::new(&handle, socket_incoming, anon_decrypt_ctx);
-
         let bootstrap_cache = try_bfut!(
             BootstrapCache::new(config.read().bootstrap_cache_name.as_ref().map(
                 |p| p.as_ref(),
             )).map_err(CrustError::ReadBootstrapCache)
         );
         bootstrap_cache.read_file();
+
+        let (listeners, socket_incoming) = Acceptor::new(
+            &handle,
+            p2p.clone(),
+            anon_decrypt_ctx.clone(),
+            our_sk.clone(),
+        );
+        let demux = Demux::new(&handle, socket_incoming, anon_decrypt_ctx, &bootstrap_cache);
 
         future::ok(Service {
             handle,

--- a/src/service.rs
+++ b/src/service.rs
@@ -261,6 +261,11 @@ impl<UID: Uid> Service<UID> {
         self.our_sk.clone()
     }
 
+    #[cfg(test)]
+    pub fn bootstrap_cache(&self) -> BootstrapCache {
+        self.bootstrap_cache.clone()
+    }
+
     /// Constructs private connection info with p2p info returned from `p2p` crate.
     /// p2p info is used for rendezvous connections - hole punching.
     fn with_p2p_connection_info(

--- a/src/util/test.rs
+++ b/src/util/test.rs
@@ -57,20 +57,20 @@ pub fn random_vec(size: usize) -> Vec<u8> {
 /// # Returns
 ///
 /// file name where content was written to.
-pub fn write_bootstrap_cache_to_tmp_file(content: &[u8]) -> String {
+pub fn write_bootstrap_cache_to_tmp_file(content: &[u8]) -> OsString {
     let mut path = unwrap!(current_bin_dir());
     let fname = format!("{:08x}.bootstrap.cache", rand::random::<u64>());
     path.push(fname.clone());
 
     let mut f = unwrap!(File::create(path));
     unwrap!(f.write_all(content));
-    fname
+    fname.into()
 }
 
 /// Constructs random bootstrap cache file name.
-pub fn bootstrap_cache_tmp_file() -> PathBuf {
+pub fn bootstrap_cache_tmp_file() -> OsString {
     let file_name = format!("{:016x}.bootstrap.cache", rand::random::<u64>());
     let mut path = env::temp_dir();
     path.push(file_name);
-    path
+    path.into()
 }

--- a/src/util/test.rs
+++ b/src/util/test.rs
@@ -20,6 +20,7 @@
 use config_file_handler::current_bin_dir;
 use priv_prelude::*;
 use rand::{self, Rng};
+use std::env;
 use std::fs::File;
 use std::io::Write;
 
@@ -64,4 +65,12 @@ pub fn write_bootstrap_cache_to_tmp_file(content: &[u8]) -> String {
     let mut f = unwrap!(File::create(path));
     unwrap!(f.write_all(content));
     fname
+}
+
+/// Constructs random bootstrap cache file name.
+pub fn bootstrap_cache_tmp_file() -> PathBuf {
+    let file_name = format!("{:016x}.bootstrap.cache", rand::random::<u64>());
+    let mut path = env::temp_dir();
+    path.push(file_name);
+    path
 }


### PR DESCRIPTION
After successful direct connection (via `connect()` or `bootstrap()`) stores peer's information into bootstrap cache which is also persisted to disk. After unsuccessful connections, peers are removed from cache.