### PR TITLE
Disable p2p connections

### DIFF
--- a/installer/sample.config
+++ b/installer/sample.config
@@ -18,6 +18,7 @@
   "network_name": null,
   "dev": {
     "disable_external_reachability_requirement": true,
-    "disable_tcp": false
+    "disable_tcp": false,
+    "disable_rendezvous_connections": false
   }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -166,6 +166,14 @@ impl ConfigFile {
         }
     }
 
+    /// Checks if rendezvous connections are disabled.
+    pub fn rendezvous_connections_disabled(&self) -> bool {
+        match self.read().dev {
+            Some(ref dev) => dev.disable_rendezvous_connections,
+            None => false,
+        }
+    }
+
     /// Attach an observer to this config. Observers will be notified via the returned channel
     /// whenever a change is made to the config.
     pub fn observe(&self) -> UnboundedReceiver<()> {
@@ -347,6 +355,9 @@ pub struct DevConfigSettings {
     pub disable_external_reachability_requirement: bool,
     /// If `true` then TCP is disabled
     pub disable_tcp: bool,
+    /// If `true`, then Crust attempts only direct connections. Useful for testing.
+    /// Default is `false`.
+    pub disable_rendezvous_connections: bool,
 }
 
 impl Default for ConfigSettings {

--- a/src/tests/compat_api.rs
+++ b/src/tests/compat_api.rs
@@ -351,10 +351,9 @@ fn bootstrap_with_disable_external_reachability() {
 
     let (event_tx0, event_rx0) = event_sender();
     let config0 = unwrap!(ConfigFile::new_temporary());
-    unwrap!(config0.write()).dev = Some(DevConfigSettings {
-        disable_external_reachability_requirement: true,
-        disable_tcp: false,
-    });
+    let mut dev_cfg = DevConfigSettings::default();
+    dev_cfg.disable_external_reachability_requirement = true;
+    unwrap!(config0.write()).dev = Some(dev_cfg);
     unwrap!(config0.write()).listen_addresses = vec![tcp_addr!("0.0.0.0:0")];
     let uid0: UniqueId = rand::random();
     let service0 = unwrap!(compat::Service::with_config(event_tx0, config0, uid0));


### PR DESCRIPTION
Add development config option to disable peer-to-peer connections.
This will allow me to write automated tests for direct connection failures.