### PR TITLE
MAID-2584: use connection info relay channel

### DIFF
--- a/src/compat/event.rs
+++ b/src/compat/event.rs
@@ -23,7 +23,7 @@ pub struct ConnectionInfoResult<UID> {
     /// The token that was passed to `prepare_connection_info`.
     pub result_token: u32,
     /// The new contact info, if successful.
-    pub result: Result<PrivConnectionInfo<UID>, CrustError>,
+    pub result: Result<PubConnectionInfo<UID>, CrustError>,
 }
 
 /// Enum representing different events that will be sent over the asynchronous channel to the user

--- a/src/error.rs
+++ b/src/error.rs
@@ -71,5 +71,16 @@ quick_error! {
             cause(e)
             from()
         }
+        /// Error connecting to peer.
+        ConnectError(e: ConnectError) {
+            description("Failed to connect to peer")
+            display("Failed to connect to peer: {}", e)
+            cause(e)
+            from()
+        }
+        /// Failed to prepare our connection information.
+        PrepareConnectionInfo {
+            description("Failed to prepare our connection info")
+        }
     }
 }

--- a/src/net/peer/connect/connection_info.rs
+++ b/src/net/peer/connect/connection_info.rs
@@ -53,7 +53,7 @@ pub struct PrivConnectionInfo<UID> {
 }
 
 /// Contact info used to connect to another peer.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PubConnectionInfo<UID> {
     #[doc(hidden)]
     pub connection_id: u64,

--- a/src/net/peer/connect/connection_info.rs
+++ b/src/net/peer/connect/connection_info.rs
@@ -36,6 +36,8 @@ pub struct P2pConnectionInfo {
 #[derive(Debug)]
 pub struct PrivConnectionInfo<UID> {
     #[doc(hidden)]
+    pub connection_id: u64,
+    #[doc(hidden)]
     pub id: UID,
     #[doc(hidden)]
     pub for_direct: Vec<PaAddr>,
@@ -53,6 +55,8 @@ pub struct PrivConnectionInfo<UID> {
 /// Contact info used to connect to another peer.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PubConnectionInfo<UID> {
+    #[doc(hidden)]
+    pub connection_id: u64,
     #[doc(hidden)]
     pub id: UID,
     #[doc(hidden)]
@@ -78,6 +82,7 @@ impl<UID: Uid> PrivConnectionInfo<UID> {
             .as_ref()
             .and_then(|conn_info| Some(conn_info.our_info.to_vec()));
         PubConnectionInfo {
+            connection_id: self.connection_id,
             for_direct: self.for_direct.clone(),
             id: self.id,
             p2p_conn_info,
@@ -103,6 +108,7 @@ mod tests {
             fn when_p2p_conn_info_is_none_it_sets_none_in_public_conn_info_too() {
                 let (our_pk, our_sk) = gen_keypair();
                 let priv_conn_info = PrivConnectionInfo {
+                    connection_id: 123,
                     id: util::random_id(),
                     for_direct: vec![],
                     p2p_conn_info: None,
@@ -126,6 +132,7 @@ mod tests {
                 });
                 let (our_pk, our_sk) = gen_keypair();
                 let priv_conn_info = PrivConnectionInfo {
+                    connection_id: 123,
                     id: util::random_id(),
                     for_direct: vec![],
                     p2p_conn_info,

--- a/src/net/peer/connect/demux.rs
+++ b/src/net/peer/connect/demux.rs
@@ -214,13 +214,13 @@ fn handle_connect_request<UID: Uid>(
     connect_request: ConnectRequest<UID>,
 ) -> BoxFuture<(), IncomingError> {
     let mut connection_handler_map = unwrap!(inner.connection_handler.lock());
-    match connection_handler_map.get(&connect_request.uid) {
+    match connection_handler_map.get(&connect_request.peer_uid) {
         Some(conn_handler) => {
             let _ = conn_handler.unbounded_send((socket, connect_request));
         }
         None => {
             let mut available_conns = unwrap!(inner.available_connections.lock());
-            let _ = available_conns.insert(connect_request.uid, (socket, connect_request));
+            let _ = available_conns.insert(connect_request.peer_uid, (socket, connect_request));
         }
     };
     future::ok(()).into_boxed()

--- a/src/net/peer/connect/demux.rs
+++ b/src/net/peer/connect/demux.rs
@@ -94,19 +94,23 @@ impl<UID: Uid> Demux<UID> {
         acceptor
     }
 
-    pub fn connect(
+    pub fn connect<C>(
         &self,
         name_hash: NameHash,
         our_info: PrivConnectionInfo<UID>,
-        their_info: PubConnectionInfo<UID>,
+        conn_info_rx: C,
         config: &ConfigFile,
-    ) -> BoxFuture<Peer<UID>, ConnectError> {
+    ) -> BoxFuture<Peer<UID>, ConnectError>
+    where
+        C: Stream<Item = PubConnectionInfo<UID>>,
+        C: 'static,
+    {
         let peer_rx = self.direct_conn_receiver(our_info.connection_id);
         connect(
             &self.inner.handle,
             name_hash,
             our_info,
-            their_info,
+            conn_info_rx,
             config,
             peer_rx,
             &self.inner.bootstrap_cache,

--- a/src/net/peer/connect/demux.rs
+++ b/src/net/peer/connect/demux.rs
@@ -35,6 +35,7 @@ const MAX_INCOMING_CONNECTIONS_BACKLOG: usize = 128;
 
 /// Demultiplexes the incoming stream of connections on the main listener and routes them to either
 /// the bootstrap acceptor (if there is one), or to the appropriate connection handler.
+#[derive(Clone)]
 pub struct Demux<UID: Uid> {
     inner: Arc<DemuxInner<UID>>,
 }

--- a/src/net/peer/connect/handshake_message.rs
+++ b/src/net/peer/connect/handshake_message.rs
@@ -28,6 +28,7 @@ pub struct BootstrapRequest<UID> {
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct ConnectRequest<UID> {
+    pub connection_id: u64,
     /// Unique ID of the peer that sent us connect request.
     pub peer_uid: UID,
     /// Public key of the peer that sent us connect request.

--- a/src/net/peer/connect/handshake_message.rs
+++ b/src/net/peer/connect/handshake_message.rs
@@ -28,9 +28,11 @@ pub struct BootstrapRequest<UID> {
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct ConnectRequest<UID> {
-    pub uid: UID,
+    /// Unique ID of the peer that sent us connect request.
+    pub peer_uid: UID,
+    /// Public key of the peer that sent us connect request.
+    pub peer_pk: PublicKey,
     pub name_hash: NameHash,
-    pub their_pk: PublicKey,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]

--- a/src/net/peer/connect/mod.rs
+++ b/src/net/peer/connect/mod.rs
@@ -148,6 +148,7 @@ pub fn connect<UID: Uid>(
 
     let their_id = their_info.id;
     let our_connect_request = ConnectRequest {
+        connection_id: their_info.connection_id,
         peer_uid: our_info.id,
         peer_pk: our_info.our_pk,
         name_hash: name_hash,

--- a/src/net/peer/connect/mod.rs
+++ b/src/net/peer/connect/mod.rs
@@ -74,6 +74,9 @@ quick_error! {
             description("peer is not whitelisted")
             display("peer {} is not whitelisted", ip)
         }
+        ExchangeConnectionInfo {
+            description("Failed to exchange connection info")
+        }
     }
 }
 

--- a/src/net/peer/connect/mod.rs
+++ b/src/net/peer/connect/mod.rs
@@ -148,9 +148,9 @@ pub fn connect<UID: Uid>(
 
     let their_id = their_info.id;
     let our_connect_request = ConnectRequest {
-        uid: our_info.id,
+        peer_uid: our_info.id,
+        peer_pk: our_info.our_pk,
         name_hash: name_hash,
-        their_pk: our_info.our_pk,
     };
     let our_id = our_info.id;
     let our_sk = our_info.our_sk.clone();
@@ -341,7 +341,7 @@ fn handshake_incoming_connections<UID: Uid>(
         .and_then(move |(mut socket, connect_request)| {
             validate_connect_request(their_id, our_connect_request.name_hash, &connect_request)?;
             socket.use_crypto_ctx(CryptoContext::authenticated(
-                connect_request.their_pk,
+                connect_request.peer_pk,
                 our_sk.clone(),
             ));
             Ok({
@@ -383,7 +383,7 @@ where
             None => Err(SingleConnectionError::ConnectionDropped),
             Some(HandshakeMessage::Connect(connect_request)) => {
                 validate_connect_request(their_id, our_name_hash, &connect_request)?;
-                Ok((socket, connect_request.uid))
+                Ok((socket, connect_request.peer_uid))
             }
             Some(_msg) => Err(SingleConnectionError::UnexpectedMessage),
         })
@@ -422,7 +422,7 @@ fn validate_connect_request<UID: Uid>(
     connect_request: &ConnectRequest<UID>,
 ) -> Result<(), SingleConnectionError> {
     let &ConnectRequest {
-        uid: their_uid,
+        peer_uid: their_uid,
         name_hash: their_name_hash,
         ..
     } = connect_request;

--- a/src/service.rs
+++ b/src/service.rs
@@ -191,17 +191,20 @@ impl<UID: Uid> Service<UID> {
         }
     }
 
-    /// Perform a p2p connection to a peer. You must generate connection info first using
-    /// `prepare_connection_info`.
+    /// Perform a p2p connection to a peer. Bidirectional channel is used to exchange connection
+    /// info with remote peer.
     pub fn connect(
         &self,
         our_info: PrivConnectionInfo<UID>,
         their_info: PubConnectionInfo<UID>,
     ) -> BoxFuture<Peer<UID>, ConnectError> {
+        // TODO(povilas): prepare our conn info and send to ci_channel
+        let (ci_channel, ci_channel_tx) = bi_channel::unbounded();
+        unwrap!(ci_channel_tx.unbounded_send(their_info));
         self.demux.connect(
             self.config.network_name_hash(),
             our_info,
-            their_info,
+            ci_channel,
             &self.config,
         )
     }

--- a/src/service.rs
+++ b/src/service.rs
@@ -22,6 +22,7 @@ use net::{self, Acceptor, BootstrapAcceptor, Demux, Listener, ServiceDiscovery};
 use net::peer::BootstrapRequest;
 use p2p::{self, P2p};
 use priv_prelude::*;
+use rand::{self, Rng};
 use rust_sodium::crypto::box_::{gen_keypair, PublicKey, SecretKey};
 
 pub const SERVICE_DISCOVERY_DEFAULT_PORT: u16 = 5483;
@@ -175,6 +176,7 @@ impl<UID: Uid> Service<UID> {
     pub fn prepare_connection_info(&self) -> BoxFuture<PrivConnectionInfo<UID>, CrustError> {
         let (direct_addrs, _) = self.listeners.addresses();
         let priv_conn_info = PrivConnectionInfo {
+            connection_id: rand::thread_rng().gen(),
             id: self.our_uid,
             for_direct: direct_addrs.into_iter().collect(),
             p2p_conn_info: None,

--- a/src/tests/compat_api.rs
+++ b/src/tests/compat_api.rs
@@ -167,7 +167,7 @@ fn start_two_services_exchange_data() {
             assert_eq!(res.result_token, token);
             unwrap!(res.result)
         });
-        unwrap!(ci_tx0.send(ci0.to_pub_connection_info()));
+        unwrap!(ci_tx0.send(ci0.clone()));
         let pub_ci1 = unwrap!(ci_rx1.recv());
 
         unwrap!(service0.connect(ci0, pub_ci1));
@@ -207,7 +207,7 @@ fn start_two_services_exchange_data() {
             assert_eq!(res.result_token, token);
             unwrap!(res.result)
         });
-        unwrap!(ci_tx1.send(ci1.to_pub_connection_info()));
+        unwrap!(ci_tx1.send(ci1.clone()));
         let pub_ci0 = unwrap!(ci_rx0.recv());
 
         unwrap!(service1.connect(ci1, pub_ci0));


### PR DESCRIPTION
This PR changes `Service::connect()` semantics and interface.
* connect() is able to return incoming connection before its connection information is received. This behavior is implemented in master branch.
* now connect() accepts connection info relay channel which is both Stream and Sink.

Compatibility API doesn't change much, except `prepare_connection_info()` returns `PubConnectionInfo` instead of private one.