### PR TITLE
fix/compat_api: MAID-2627

### DIFF
--- a/src/compat/service.rs
+++ b/src/compat/service.rs
@@ -357,7 +357,7 @@ impl<UID: Uid> Service<UID> {
         self.event_loop
             .send(Box::new(move |state: &mut ServiceState<UID>| {
                 if let Some(ci_chann) = state.cm.get_ci_channel(our_ci.connection_id) {
-                    unwrap!(ci_chann.unbounded_send(their_ci));
+                    let _ = ci_chann.unbounded_send(their_ci);
                 }
             }));
         Ok(())


### PR DESCRIPTION
Since we no longer make compat-api users call `connect` to accept a connection it's possible for the connection to have completed before they call `connect`. This will cause the other end of the ci channel to have been dropped when `compat::Service::connect` tries to send on it.