### PR TITLE
MAID-2733: shuffle bootstrap peers

### DIFF
--- a/src/net/peer/connect/bootstrap/cache.rs
+++ b/src/net/peer/connect/bootstrap/cache.rs
@@ -95,9 +95,16 @@ impl Cache {
     }
 
     /// Returns current snapshot of peers in the cache.
+    #[cfg(test)]
     pub fn peers(&self) -> HashSet<PeerInfo> {
         let inner = unwrap!(self.inner.lock());
         inner.peers.clone()
+    }
+
+    /// Returns `Vec` of peers in the cache.
+    pub fn peers_vec(&self) -> Vec<PeerInfo> {
+        let inner = unwrap!(self.inner.lock());
+        inner.peers.iter().cloned().collect()
     }
 }
 

--- a/src/net/peer/connect/bootstrap/mod.rs
+++ b/src/net/peer/connect/bootstrap/mod.rs
@@ -88,12 +88,10 @@ pub fn bootstrap<UID: Uid>(
     } else {
         future::ok(stream::empty().into_boxed()).into_boxed()
     };
-
-    let cached_peers = future::result(bootstrap_peers(&config, &cache));
+    let cached_peers = bootstrap_peers(&config, &cache);
 
     sd_peers
-        .join(cached_peers)
-        .and_then(move |(sd_peers, cached_peers)| {
+        .and_then(move |sd_peers| {
             let mut i = 0;
 
             sd_peers
@@ -159,11 +157,11 @@ fn bootstrap_to_peer<UID: Uid>(
 }
 
 /// Collects bootstrap peers from cache and config.
-fn bootstrap_peers(config: &ConfigFile, cache: &Cache) -> Result<Vec<PeerInfo>, BootstrapError> {
+fn bootstrap_peers(config: &ConfigFile, cache: &Cache) -> Vec<PeerInfo> {
     let mut peers = Vec::new();
     peers.extend(cache.peers());
     peers.extend(config.read().hard_coded_contacts.clone());
-    Ok(peers)
+    peers
 }
 
 #[cfg(test)]
@@ -183,7 +181,7 @@ mod tests {
             let cache = unwrap!(Cache::new(Some(&bootstrap_cache_tmp_file())));
             cache.put(&PeerInfo::with_rand_key(tcp_addr!("1.2.3.5:5000")));
 
-            let peers: Vec<PaAddr> = unwrap!(bootstrap_peers(&config, &cache))
+            let peers: Vec<PaAddr> = bootstrap_peers(&config, &cache)
                 .iter()
                 .map(|peer| peer.addr)
                 .collect();

--- a/src/net/service_discovery/discover.rs
+++ b/src/net/service_discovery/discover.rs
@@ -27,6 +27,8 @@ use tokio_core::net::UdpSocket;
 use tokio_core::reactor::Handle;
 use util::SerdeUdpCodec;
 
+/// Returns IP address and listener addresses of a first node to respond to service discovery
+/// request.
 pub fn discover<T>(
     handle: &Handle,
     port: u16,


### PR DESCRIPTION
1. attempt bootstrap in stages: service discovery, then cached peers, then hard coded contacts
2. each time randomly shuffle cached and hard coded peers