### PR TITLE
MAID-2511: fix compat layer

### DIFF
--- a/src/compat/connection_map.rs
+++ b/src/compat/connection_map.rs
@@ -197,7 +197,7 @@ fn handle_peer_rx(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use util::event_sender;
+    use util::crust_event_channel;
 
     mod handle_peer_rx {
         use super::*;
@@ -230,7 +230,7 @@ mod tests {
             let peer_uid = peer.public_id();
             let (peer_sink, peer_stream) = peer.split();
             let (_rop_tx, drop_rx) = future_utils::drop_notify();
-            let (event_tx, event_rx) = event_sender();
+            let (event_tx, event_rx) = crust_event_channel();
             let conn_map = ConnectionMap::new(event_tx.clone());
 
             handle.spawn(handle_peer_rx(

--- a/src/compat/connection_map.rs
+++ b/src/compat/connection_map.rs
@@ -17,8 +17,8 @@
 
 use compat::{CompatPeer, CrustEventSender, Event, Priority};
 use future_utils::bi_channel::UnboundedBiChannel;
-use future_utils::{self, DropNotify};
-use futures::stream::SplitSink;
+use future_utils::{self, DropNotice, DropNotify};
+use futures::stream::{SplitSink, SplitStream};
 use log::LogLevel;
 use priv_prelude::*;
 use std::sync::{Arc, Mutex};
@@ -58,7 +58,6 @@ impl ConnectionMap {
 
     /// Insert new peer into the map and registers peer event handlers.
     pub fn insert_peer(&self, handle: &Handle, peer: CompatPeer, addr: PaAddr) -> bool {
-        let cm = self.clone();
         let (drop_tx, drop_rx) = future_utils::drop_notify();
         let uid = peer.public_id();
         let kind = peer.kind();
@@ -69,26 +68,14 @@ impl ConnectionMap {
             return false;
         }
 
-        let event_tx0 = inner.event_tx.clone();
-        let event_tx1 = inner.event_tx.clone();
-        handle.spawn({
-            let uid0 = uid.clone();
-            let uid1 = uid.clone();
-            let uid2 = uid.clone();
-            peer_stream
-                .log_errors(LogLevel::Info, "receiving data from peer")
-                .until(drop_rx)
-                .for_each(move |msg| {
-                    let vec = Vec::from(&msg[..]);
-                    let _ = event_tx0.send(Event::NewMessage(uid1.clone(), kind, vec));
-                    Ok(())
-                })
-                .finally(move || {
-                    let _ = cm.remove(&uid0);
-                    let _ = event_tx1.send(Event::LostPeer(uid2));
-                })
-                .infallible()
-        });
+        handle.spawn(handle_peer_rx(
+            peer_stream,
+            &uid,
+            &inner.event_tx,
+            drop_rx,
+            kind,
+            self.clone(),
+        ));
 
         let pw = PeerWrapper {
             _drop_tx: drop_tx,
@@ -96,7 +83,6 @@ impl ConnectionMap {
             kind,
             peer_sink,
         };
-
         let _ = inner.map.insert(uid, pw);
         true
     }
@@ -177,5 +163,97 @@ impl ConnectionMap {
     ) -> Option<UnboundedBiChannel<PubConnectionInfo>> {
         let mut inner = unwrap!(self.inner.lock());
         inner.ci_channel.remove(&conn_id)
+    }
+}
+
+/// Wait for incoming peer data and transform it to appropriate compatibility layer events.
+fn handle_peer_rx(
+    peer_stream: SplitStream<CompatPeer>,
+    uid: &PublicId,
+    event_tx: &CrustEventSender,
+    drop_rx: DropNotice,
+    kind: CrustUser,
+    cm: ConnectionMap,
+) -> impl Future<Item = (), Error = ()> {
+    let event_tx0 = event_tx.clone();
+    let event_tx1 = event_tx.clone();
+    let uid1 = uid.clone();
+    let uid2 = uid.clone();
+    peer_stream
+        .log_errors(LogLevel::Info, "receiving data from peer")
+        .until(drop_rx)
+        .for_each(move |msg| {
+            let vec = Vec::from(&msg[..]);
+            let _ = event_tx0.send(Event::NewMessage(uid1.clone(), kind, vec));
+            Ok(())
+        })
+        .finally(move || {
+            let _ = cm.remove(&uid2);
+            let _ = event_tx1.send(Event::LostPeer(uid2));
+        })
+        .infallible()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use util::event_sender;
+
+    mod handle_peer_rx {
+        use super::*;
+        use net::peer;
+        use tokio_core::reactor::{Core, Handle};
+        use tokio_io::codec::length_delimited::Framed;
+
+        /// Constructs peer with in-memory stream for testing.
+        fn echo_peer(handle: &Handle) -> CompatPeer {
+            let our_sk = SecretId::new();
+            let peer_uid = SecretId::new().public_id().clone();
+            let shared_secret = our_sk.shared_secret(&peer_uid);
+            let mem_stream = Framed::new(memstream::EchoStream::default());
+            let fake_stream = PaStream::from_framed_mem_stream(mem_stream, shared_secret);
+            let peer = peer::from_handshaken_stream(
+                &handle,
+                peer_uid.clone(),
+                fake_stream,
+                CrustUser::Client,
+            );
+            CompatPeer::wrap_peer(&handle, peer, peer_uid.clone(), tcp_addr!("0.0.0.0:0"))
+        }
+
+        #[test]
+        fn it_emits_message_events_for_received_data() {
+            let mut evloop = unwrap!(Core::new());
+            let handle = evloop.handle();
+
+            let peer = echo_peer(&handle);
+            let peer_uid = peer.public_id();
+            let (peer_sink, peer_stream) = peer.split();
+            let (_rop_tx, drop_rx) = future_utils::drop_notify();
+            let (event_tx, event_rx) = event_sender();
+            let conn_map = ConnectionMap::new(event_tx.clone());
+
+            handle.spawn(handle_peer_rx(
+                peer_stream,
+                &peer_uid,
+                &event_tx,
+                drop_rx,
+                CrustUser::Client,
+                conn_map,
+            ));
+            let send_data = peer_sink.send((1, Bytes::from(&b"data1"[..])));
+            let _ = unwrap!(evloop.run(send_data));
+            // run event loop so that messages would get transfered
+            unwrap!(evloop.run(Timeout::new(Duration::from_secs(2), &handle)));
+
+            let msg = unwrap!(event_rx.recv());
+            match msg {
+                Event::NewMessage(_, _, data) => {
+                    assert_eq!(data.len(), 5);
+                    assert_eq!(&data[..5], &b"data1"[..5]);
+                }
+                event => panic!("Unexpected event: {:?}", event),
+            }
+        }
     }
 }

--- a/src/compat/peer.rs
+++ b/src/compat/peer.rs
@@ -96,7 +96,7 @@ impl CompatPeer {
         unwrap!(self.inner.as_ref()).uid.clone()
     }
 
-    /// Wraps a `PaStream` and turns it into a `CompatPeer`.
+    /// Wraps a `Peer` and turns it into a `CompatPeer`.
     pub fn wrap_peer(handle: &Handle, peer: Peer, uid: PublicId, peer_addr: PaAddr) -> CompatPeer {
         let kind = peer.kind();
         let (stream_tx, stream_rx) = peer.split();
@@ -319,7 +319,7 @@ mod test {
     use tokio_core::reactor::Core;
     use util;
 
-    mod socket {
+    mod compat_peer {
         use super::*;
         use rand::{self, Rng};
 
@@ -417,7 +417,7 @@ mod test {
         }
     }
 
-    mod socket_task {
+    mod compat_peer_task {
         use super::*;
 
         mod poll_task {

--- a/src/priv_prelude.rs
+++ b/src/priv_prelude.rs
@@ -58,4 +58,6 @@ pub use tokio_core::reactor::Handle;
 pub use tokio_io::codec::length_delimited::Framed;
 pub use tokio_io::{AsyncRead, AsyncWrite};
 pub use tokio_utp::{UtpListener, UtpSocket, UtpStream};
+#[cfg(test)]
+pub use util::memstream;
 pub use void::{ResultVoidExt, Void};

--- a/src/tests/compat_api.rs
+++ b/src/tests/compat_api.rs
@@ -23,7 +23,7 @@ use rand;
 use std;
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
-use util::{self, event_sender};
+use util::{self, crust_event_channel};
 
 // Receive an event from the given receiver and asserts that it matches the
 // given pattern.
@@ -44,7 +44,7 @@ macro_rules! expect_event {
 }
 
 fn service_with_config(config: ConfigFile) -> (compat::Service, Receiver<Event>) {
-    let (event_tx, event_rx) = event_sender();
+    let (event_tx, event_rx) = crust_event_channel();
     let sk = SecretId::new();
     let service = unwrap!(compat::Service::with_config(event_tx, config, sk));
     (service, event_rx)
@@ -250,7 +250,7 @@ mod bootstrap {
 
         unwrap!(service0.set_accept_bootstrap(true));
 
-        let (event_tx1, event_rx1) = event_sender();
+        let (event_tx1, event_rx1) = crust_event_channel();
         let config1 = unwrap!(ConfigFile::new_temporary());
         unwrap!(config1.write()).bootstrap_cache_name = Some(util::bootstrap_cache_tmp_file());
         unwrap!(config1.write()).hard_coded_contacts =
@@ -359,7 +359,7 @@ mod bootstrap {
     fn with_disable_external_reachability() {
         let _ = env_logger::init();
 
-        let (event_tx0, event_rx0) = event_sender();
+        let (event_tx0, event_rx0) = crust_event_channel();
         let config0 = unwrap!(ConfigFile::new_temporary());
         let mut dev_cfg = DevConfigSettings::default();
         dev_cfg.disable_external_reachability_requirement = true;

--- a/src/tests/compat_api.rs
+++ b/src/tests/compat_api.rs
@@ -15,16 +15,15 @@
 // Please review the Licences for the specific language governing permissions and limitations
 // relating to use of the SAFE Network Software.
 
-use compat::{self, CrustEventSender, Event};
+use compat::{self, Event};
 use config::{DevConfigSettings, PeerInfo};
 use env_logger;
-use maidsafe_utilities::event_sender::{MaidSafeEventCategory, MaidSafeObserver};
 use priv_prelude::*;
 use rand;
 use std;
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
-use util;
+use util::{self, event_sender};
 
 // Receive an event from the given receiver and asserts that it matches the
 // given pattern.
@@ -42,16 +41,6 @@ macro_rules! expect_event {
             e => panic!("unexpected event {:?}", e),
         }
     };
-}
-
-fn event_sender() -> (CrustEventSender, Receiver<Event>) {
-    let (category_tx, _) = mpsc::channel();
-    let (event_tx, event_rx) = mpsc::channel();
-
-    (
-        MaidSafeObserver::new(event_tx, MaidSafeEventCategory::Crust, category_tx),
-        event_rx,
-    )
 }
 
 fn service_with_config(config: ConfigFile) -> (compat::Service, Receiver<Event>) {

--- a/src/util/memstream.rs
+++ b/src/util/memstream.rs
@@ -1,0 +1,163 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// https://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! Tokio compatible in-memory stream implementation. Helpful for testing.
+
+// TODO(povilas): move to future_utils crate - this module is generic and highly reusable.
+
+use priv_prelude::*;
+use std::cmp;
+use std::io::{self, Read, Write};
+
+/// In-memory stream implementing `AsyncWrite + AsyncRead`. This stream is not connected with
+/// any other stream. Meaning what you write to the stream you can later read from it.
+#[derive(Default, Debug)]
+pub struct EchoStream {
+    buf: Vec<u8>,
+    shutdown: bool,
+}
+
+impl Read for EchoStream {
+    /// Reads as much data as possible to the given buffer and removes that data from internal
+    /// buffer.
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.buf.is_empty() {
+            if self.shutdown {
+                return Ok(0);
+            } else {
+                return Err(io::ErrorKind::WouldBlock.into());
+            }
+        }
+
+        let bytes_to_read = cmp::min(self.buf.len(), buf.len());
+        buf.iter_mut()
+            .zip(self.buf.drain(..bytes_to_read))
+            .for_each(|(dst, src)| *dst = src);
+        Ok(bytes_to_read)
+    }
+}
+
+impl Write for EchoStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl AsyncRead for EchoStream {}
+
+impl AsyncWrite for EchoStream {
+    /// Analogous to sending FIN to myself.
+    /// This will unblock `read()` calls which will get 0 as result value.
+    fn shutdown(&mut self) -> io::Result<Async<()>> {
+        self.shutdown = true;
+        Ok(Async::Ready(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod echostream {
+        use super::*;
+        use tokio_core::reactor::Core;
+        use tokio_io;
+
+        mod read {
+            use super::*;
+
+            mod when_stream_is_empty {
+                use super::*;
+
+                #[test]
+                fn when_stream_is_open_it_returns_would_block_error() {
+                    let mut stream = EchoStream::default();
+
+                    let mut data = [0; 4];
+                    let res = stream.read(&mut data);
+
+                    match res {
+                        Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => (),
+                        res => panic!("Unexpected read() result: {:?}", res),
+                    }
+                }
+
+                #[test]
+                fn when_stream_is_closed_it_returns_0() {
+                    let mut stream = EchoStream::default();
+                    stream.shutdown = true;
+
+                    let mut data = [0; 4];
+                    let bytes_read = unwrap!(stream.read(&mut data));
+
+                    assert_eq!(bytes_read, 0);
+                }
+            }
+
+            #[test]
+            fn it_removes_bytes_read_from_internal_buffer() {
+                let mut stream = EchoStream::default();
+                stream.buf.extend_from_slice(b"data1");
+
+                let mut data = [0; 8];
+                let _ = unwrap!(stream.read(&mut data));
+
+                assert!(stream.buf.is_empty());
+            }
+
+            #[test]
+            fn when_given_buffer_is_smaller_than_internal_one_it_reads_in_chunks() {
+                let mut stream = EchoStream::default();
+                stream.buf.extend_from_slice(b"data1");
+                stream.buf.extend_from_slice(b"data2");
+
+                let mut data = [0; 5];
+                let _ = unwrap!(stream.read(&mut data));
+                assert_eq!(&data, b"data1");
+
+                let _ = unwrap!(stream.read(&mut data));
+                assert_eq!(&data, b"data2");
+            }
+        }
+
+        #[test]
+        fn writes_reads_are_reflective() {
+            let mut stream = EchoStream::default();
+            let _ = unwrap!(stream.write(b"data1"));
+            let _ = unwrap!(stream.write(b"data2"));
+
+            let mut data = [0; 16];
+            let bytes_read = unwrap!(stream.read(&mut data));
+
+            assert_eq!(bytes_read, 10);
+            assert_eq!(data[..10], b"data1data2"[..10]);
+        }
+
+        #[test]
+        fn async_writes_reads() {
+            let mut evloop = unwrap!(Core::new());
+            let stream = EchoStream::default();
+
+            let write_read = tokio_io::io::write_all(stream, b"data1")
+                .and_then(|(stream, _)| tokio_io::io::write_all(stream, b"data2"))
+                .and_then(|(stream, _)| tokio_io::io::shutdown(stream))
+                .and_then(|stream| tokio_io::io::read_to_end(stream, Vec::new()))
+                .and_then(|(_stream, data)| Ok(data));
+            let data_read = unwrap!(evloop.run(write_read));
+
+            assert_eq!(data_read.len(), 10);
+            assert_eq!(data_read[..10], b"data1data2"[..10]);
+        }
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -16,6 +16,8 @@
 // relating to use of the SAFE Network Software.
 
 mod ip_addr;
+#[cfg(test)]
+pub mod memstream;
 mod serde_udp_codec;
 
 pub use self::ip_addr::*;

--- a/src/util/test.rs
+++ b/src/util/test.rs
@@ -61,7 +61,7 @@ pub fn bootstrap_cache_tmp_file() -> OsString {
 }
 
 /// Constructs event sender/receiver pair.
-pub fn event_sender() -> (CrustEventSender, Receiver<Event>) {
+pub fn crust_event_channel() -> (CrustEventSender, Receiver<Event>) {
     let (category_tx, _) = mpsc::channel();
     let (event_tx, event_rx) = mpsc::channel();
 

--- a/src/util/test.rs
+++ b/src/util/test.rs
@@ -17,12 +17,15 @@
 
 //! Utilities for use in tests. This module is only available when running with cfg(test)
 
+use compat::{CrustEventSender, Event};
 use config_file_handler::current_bin_dir;
+use maidsafe_utilities::event_sender::{MaidSafeEventCategory, MaidSafeObserver};
 use priv_prelude::*;
 use rand::{self, Rng};
 use std::env;
 use std::fs::File;
 use std::io::Write;
+use std::sync::mpsc::{self, Receiver};
 
 #[allow(unsafe_code)]
 pub fn random_vec(size: usize) -> Vec<u8> {
@@ -55,4 +58,15 @@ pub fn bootstrap_cache_tmp_file() -> OsString {
     let mut path = env::temp_dir();
     path.push(file_name);
     path.into()
+}
+
+/// Constructs event sender/receiver pair.
+pub fn event_sender() -> (CrustEventSender, Receiver<Event>) {
+    let (category_tx, _) = mpsc::channel();
+    let (event_tx, event_rx) = mpsc::channel();
+
+    (
+        MaidSafeObserver::new(event_tx, MaidSafeEventCategory::Crust, category_tx),
+        event_rx,
+    )
 }


### PR DESCRIPTION
Fixes `InactivityImeout` error handling in compatibility layer. This error is translated into`LostPeer` event.