### PR TITLE
 MAID-2956: store public keys to file

### DIFF
--- a/installer/sample.config
+++ b/installer/sample.config
@@ -22,6 +22,7 @@
   "service_discovery_port": null,
   "bootstrap_cache_name": null,
   "network_name": null,
+  "output_encryption_keys": null,
   "dev": {
     "disable_external_reachability_requirement": true,
     "disable_tcp": false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -340,6 +340,8 @@ pub struct ConfigSettings {
     /// This is a mechanism to prevent nodes from different decentralized
     /// networks to connect to each other (issue #209)
     pub network_name: Option<String>,
+    /// If set, write Crust encryption keys to this file. Default is None.
+    pub output_encryption_keys: Option<PathBuf>,
     /// Optional developer configuration
     pub dev: Option<DevConfigSettings>,
 }
@@ -367,6 +369,7 @@ impl Default for ConfigSettings {
             whitelisted_node_ips: None,
             whitelisted_client_ips: None,
             network_name: None,
+            output_encryption_keys: None,
             dev: None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ extern crate rand;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
+extern crate serde_json;
 extern crate tiny_keccak;
 extern crate tokio_core;
 extern crate tokio_io;


### PR DESCRIPTION
Adds config option to store Crust encryption keys to external file. This make it easier to configure hard coded contacts for multiple Crust nodes.