### PR TITLE
Update p2p

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ version = "~0.4"
 
 [dependencies.p2p]
 git = "https://github.com/ustulation/p2p"
-rev = "59aeb8b"
+rev = "595fa57"
 
 [dependencies.tokio-utp]
 git = "https://github.com/maidsafe/tokio_utp"

--- a/src/net/protocol_agnostic/listener.rs
+++ b/src/net/protocol_agnostic/listener.rs
@@ -152,9 +152,9 @@ impl PaListener {
     ) -> BoxFuture<(PaListener, PaAddr), BindPublicError> {
         let handle = handle.clone();
         match *addr {
-            PaAddr::Tcp(ref tcp_addr) => TcpListener::bind_public(tcp_addr, &handle, p2p)
+            PaAddr::Tcp(ref tcp_addr) => p2p::tcp_bind_public_with_addr(tcp_addr, &handle, p2p)
                 .map_err(BindPublicError::BindTcp)
-                .map(move |(listener, public_addr)| {
+                .map(move |(listener, _local_addr, public_addr)| {
                     let listener = Self {
                         handle,
                         inner: PaListenerInner::Tcp(listener),
@@ -164,9 +164,9 @@ impl PaListener {
                     let public_addr = PaAddr::Tcp(public_addr);
                     (listener, public_addr)
                 }).into_boxed(),
-            PaAddr::Utp(utp_addr) => UdpSocket::bind_public(&utp_addr, &handle, p2p)
+            PaAddr::Utp(utp_addr) => p2p::udp_bind_public_with_addr(&utp_addr, &handle, p2p)
                 .map_err(BindPublicError::BindUdp)
-                .and_then(move |(socket, public_addr)| {
+                .and_then(move |(socket, _local_addr, public_addr)| {
                     let (socket, listener) = {
                         UtpSocket::from_socket(socket, &handle)
                             .map_err(BindPublicError::MakeUtpSocket)?

--- a/src/net/protocol_agnostic/stream.rs
+++ b/src/net/protocol_agnostic/stream.rs
@@ -248,7 +248,7 @@ impl PaStream {
                 let tcp_connect = tcp_connect.map(|(stream, our_public_addr)| PaStream {
                     inner: PaStreamInner::Tcp(Framed::new(stream)),
                     shared_secret: shared_key0,
-                    our_public_addr,
+                    our_public_addr: Some(our_public_addr),
                 });
                 if our_pk > their_pk {
                     let utp_connect = {
@@ -260,7 +260,7 @@ impl PaStream {
                                     .map(move |stream| PaStream {
                                         inner: PaStreamInner::Utp(Framed::new(stream)),
                                         shared_secret,
-                                        our_public_addr,
+                                        our_public_addr: Some(our_public_addr),
                                     })
                             }).map_err(PaRendezvousConnectError::UtpFailure)
                             .and_then(|stream| {
@@ -298,7 +298,7 @@ impl PaStream {
                                     .map(move |stream| PaStream {
                                         inner: PaStreamInner::Utp(Framed::new(stream)),
                                         shared_secret,
-                                        our_public_addr,
+                                        our_public_addr: Some(our_public_addr),
                                     })
                             }).map_err(PaRendezvousConnectError::UtpFailure)
                             .and_then(take_chosen)

--- a/src/net/protocol_agnostic/stream.rs
+++ b/src/net/protocol_agnostic/stream.rs
@@ -725,23 +725,11 @@ where
 
 #[cfg(test)]
 mod test {
+    use super::super::listener::spawn_stun_server;
     use super::*;
     use config::DevConfigSettings;
     use future_utils::bi_channel;
     use tokio_core::reactor::Core;
-
-    fn spawn_stun_server(handle: &Handle, listen_addr: PaAddr) -> (SocketAddr, PublicEncryptKey) {
-        let (pk, sk) = gen_encrypt_keypair();
-        let listener = unwrap!(PaListener::bind(&listen_addr, &handle, sk, pk));
-        let listener_addr = unwrap!(listener.local_addr());
-
-        let task = listener
-            .incoming()
-            .for_each(|_stream| Ok(()))
-            .then(|_| Ok(()));
-        handle.spawn(task);
-        (listener_addr.inner().unspecified_to_localhost(), pk)
-    }
 
     #[test]
     fn rendezvous_connect_with_tcp_disabled_connects_doesnt_use_tcp() {

--- a/src/service.rs
+++ b/src/service.rs
@@ -301,7 +301,7 @@ impl Service {
             our_sk: self.our_sk.clone(),
         };
 
-        if self.listeners.has_public_addrs() {
+        if self.listeners.has_public_addrs() || self.config.rendezvous_connections_disabled() {
             future::ok(priv_conn_info).into_boxed()
         } else {
             self.with_p2p_connection_info(priv_conn_info)

--- a/src/tests/service_tests.rs
+++ b/src/tests/service_tests.rs
@@ -8,7 +8,6 @@
 // Software.
 
 use config::{DevConfigSettings, PeerInfo};
-use env_logger;
 use future_utils::bi_channel;
 use futures::stream;
 use priv_prelude::*;
@@ -242,31 +241,6 @@ mod direct_connections {
         let service2_peer = PeerInfo::new(unwrap!(service2_peer.addr()), service1.public_id());
         assert!(service2.bootstrap_cache().peers().contains(&service2_peer));
     }
-}
-
-// None of the services in this test has listeners, therefore peer-to-peer connections are made.
-#[test]
-fn p2p_connections_on_localhost() {
-    let _ = env_logger::init();
-
-    let mut event_loop = unwrap!(Core::new());
-
-    let config = unwrap!(ConfigFile::new_temporary());
-    let service1 = service_with_config(&mut event_loop, config);
-
-    let config = unwrap!(ConfigFile::new_temporary());
-    let service2 = service_with_config(&mut event_loop, config);
-
-    let (ci_channel1, ci_channel2) = bi_channel::unbounded();
-    let connect = service1
-        .connect(ci_channel1)
-        .join(service2.connect(ci_channel2))
-        .with_timeout(Duration::from_secs(10), &event_loop.handle())
-        .map(|res_opt| unwrap!(res_opt, "p2p connection timed out"));
-
-    let (service1_peer, service2_peer) = unwrap!(event_loop.run(connect));
-    assert_eq!(service1_peer.public_id(), &service2.public_id());
-    assert_eq!(service2_peer.public_id(), &service1.public_id());
 }
 
 #[test]


### PR DESCRIPTION
Use the latest p2p crate version which doesn't attempt direct connections. `rendezvous_connect()` functions now always return public rendezvous address or fail.