### PR TITLE
Fix connect_all

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ version = "~0.4"
 
 [dependencies.p2p]
 git = "https://github.com/ustulation/p2p"
-rev = "59aeb8b"
+rev = "595fa57"
 
 [dependencies.tokio-utp]
 git = "https://github.com/maidsafe/tokio_utp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,7 @@ connections_info = []
 [target."cfg(target_os = \"linux\")".dependencies.netsim]
 optional = true
 version = "~0.2.2"
+
+[[example]]
+name = "connect_all"
+required-features = ["connections_info"]

--- a/examples/connect_all.rs
+++ b/examples/connect_all.rs
@@ -1,0 +1,96 @@
+// Copyright 2018 MaidSafe.net limited.
+//
+// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
+// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
+// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
+// modified, or distributed except according to those terms. Please review the Licences for the
+// specific language governing permissions and limitations relating to use of the SAFE Network
+// Software.
+
+//! This example demonstrates `Service::connect_all()` use. This function attempts multiple
+//! connections in parallel and returns the results for all attempts disregard to failures.
+//! This method could be used for debugging or to collect connectivity information.
+
+extern crate clap;
+extern crate env_logger;
+extern crate future_utils;
+extern crate futures;
+extern crate rand;
+extern crate serde;
+extern crate serde_json;
+extern crate tokio_core;
+#[macro_use]
+extern crate unwrap;
+extern crate safe_crypto;
+extern crate void;
+
+extern crate crust;
+
+mod utils;
+
+use clap::App;
+use crust::{ConfigFile, Service};
+use future_utils::{bi_channel, FutureExt};
+use futures::{stream, Future, Stream};
+use safe_crypto::gen_encrypt_keypair;
+use tokio_core::reactor::Core;
+
+fn main() {
+    unwrap!(env_logger::init());
+
+    let _ = App::new("Crust connect_all() example")
+        .about(
+            "Attempts to connect to remote peer given its connection information. \
+             Start two instances of this example. Each instance generates and prints its \
+             connection information to stdout in JSON format. You have to manually copy/paste \
+             this info from one instance to the other and hit ENTER to start connection.",
+        ).get_matches();
+
+    let mut event_loop = unwrap!(Core::new());
+    let handle = event_loop.handle();
+    let (service_pk, service_sk) = gen_encrypt_keypair();
+    println!("Service public id: {:?}", service_pk);
+
+    let config = unwrap!(ConfigFile::new_temporary());
+    unwrap!(config.write()).listen_addresses = vec![
+        unwrap!("tcp://0.0.0.0:0".parse()),
+        unwrap!("utp://0.0.0.0:0".parse()),
+    ];
+    let make_service = Service::with_config(&event_loop.handle(), config, service_sk, service_pk);
+    let service = unwrap!(
+        event_loop.run(make_service),
+        "Failed to create Service object",
+    );
+
+    let listeners = unwrap!(
+        event_loop.run(service.start_listening().collect()),
+        "Failed to start listening to peers",
+    );
+    for listener in &listeners {
+        println!("Listening on {}", listener.addr());
+    }
+
+    let (ci_channel1, ci_channel2) = bi_channel::unbounded();
+    utils::exchange_conn_info(&handle, ci_channel2);
+
+    let connections = service.connect_all(ci_channel1).collect();
+    let connections = unwrap!(event_loop.run(connections));
+    println!("Connection attempts:");
+    for conn in connections.iter() {
+        println!("\n{:?}", conn);
+    }
+
+    let finalize_conns = stream::futures_unordered(
+        connections
+            .into_iter()
+            .filter_map(|conn_result| conn_result.result.ok())
+            .map(|peer| peer.finalize()),
+    ).map_err(|e| {
+        println!("Erorr to finalize the connection: {}", e);
+        e
+    }).for_each(|_| Ok(()))
+    .then(|_| Ok(()))
+    .infallible::<()>();
+
+    unwrap!(event_loop.run(finalize_conns));
+}

--- a/src/net/peer/connect/demux.rs
+++ b/src/net/peer/connect/demux.rs
@@ -107,6 +107,7 @@ impl Demux {
     #[cfg(feature = "connections_info")]
     pub fn connect_all<C>(
         &self,
+        name_hash: NameHash,
         our_conn_info: PrivConnectionInfo,
         conn_info_rx: C,
         config: &ConfigFile,
@@ -118,6 +119,7 @@ impl Demux {
         let peer_rx = self.direct_conn_receiver(our_conn_info.connection_id);
         connect_all(
             &self.inner.handle,
+            name_hash,
             our_conn_info,
             conn_info_rx,
             config,

--- a/src/net/protocol_agnostic/listener.rs
+++ b/src/net/protocol_agnostic/listener.rs
@@ -152,9 +152,9 @@ impl PaListener {
     ) -> BoxFuture<(PaListener, PaAddr), BindPublicError> {
         let handle = handle.clone();
         match *addr {
-            PaAddr::Tcp(ref tcp_addr) => TcpListener::bind_public(tcp_addr, &handle, p2p)
+            PaAddr::Tcp(ref tcp_addr) => p2p::tcp_bind_public_with_addr(tcp_addr, &handle, p2p)
                 .map_err(BindPublicError::BindTcp)
-                .map(move |(listener, public_addr)| {
+                .map(move |(listener, _local_addr, public_addr)| {
                     let listener = Self {
                         handle,
                         inner: PaListenerInner::Tcp(listener),
@@ -164,9 +164,9 @@ impl PaListener {
                     let public_addr = PaAddr::Tcp(public_addr);
                     (listener, public_addr)
                 }).into_boxed(),
-            PaAddr::Utp(utp_addr) => UdpSocket::bind_public(&utp_addr, &handle, p2p)
+            PaAddr::Utp(utp_addr) => p2p::udp_bind_public_with_addr(&utp_addr, &handle, p2p)
                 .map_err(BindPublicError::BindUdp)
-                .and_then(move |(socket, public_addr)| {
+                .and_then(move |(socket, _local_addr, public_addr)| {
                     let (socket, listener) = {
                         UtpSocket::from_socket(socket, &handle)
                             .map_err(BindPublicError::MakeUtpSocket)?

--- a/src/net/protocol_agnostic/stream.rs
+++ b/src/net/protocol_agnostic/stream.rs
@@ -248,7 +248,7 @@ impl PaStream {
                 let tcp_connect = tcp_connect.map(|(stream, our_public_addr)| PaStream {
                     inner: PaStreamInner::Tcp(Framed::new(stream)),
                     shared_secret: shared_key0,
-                    our_public_addr,
+                    our_public_addr: Some(our_public_addr),
                 });
                 if our_pk > their_pk {
                     let utp_connect = {
@@ -260,7 +260,7 @@ impl PaStream {
                                     .map(move |stream| PaStream {
                                         inner: PaStreamInner::Utp(Framed::new(stream)),
                                         shared_secret,
-                                        our_public_addr,
+                                        our_public_addr: Some(our_public_addr),
                                     })
                             }).map_err(PaRendezvousConnectError::UtpFailure)
                             .and_then(|stream| {
@@ -298,7 +298,7 @@ impl PaStream {
                                     .map(move |stream| PaStream {
                                         inner: PaStreamInner::Utp(Framed::new(stream)),
                                         shared_secret,
-                                        our_public_addr,
+                                        our_public_addr: Some(our_public_addr),
                                     })
                             }).map_err(PaRendezvousConnectError::UtpFailure)
                             .and_then(take_chosen)

--- a/src/net/protocol_agnostic/stream.rs
+++ b/src/net/protocol_agnostic/stream.rs
@@ -725,23 +725,11 @@ where
 
 #[cfg(test)]
 mod test {
+    use super::super::listener::spawn_stun_server;
     use super::*;
     use config::DevConfigSettings;
     use future_utils::bi_channel;
     use tokio_core::reactor::Core;
-
-    fn spawn_stun_server(handle: &Handle, listen_addr: PaAddr) -> (SocketAddr, PublicEncryptKey) {
-        let (pk, sk) = gen_encrypt_keypair();
-        let listener = unwrap!(PaListener::bind(&listen_addr, &handle, sk, pk));
-        let listener_addr = unwrap!(listener.local_addr());
-
-        let task = listener
-            .incoming()
-            .for_each(|_stream| Ok(()))
-            .then(|_| Ok(()));
-        handle.spawn(task);
-        (listener_addr.inner().unspecified_to_localhost(), pk)
-    }
 
     #[test]
     fn rendezvous_connect_with_tcp_disabled_connects_doesnt_use_tcp() {

--- a/src/service.rs
+++ b/src/service.rs
@@ -213,6 +213,7 @@ impl Service {
                     .send(our_info.to_pub_connection_info())
                     .map_err(|_e| SingleConnectionError::DeadChannel)
                     .while_driving(future::ok(demux.connect_all(
+                        config.network_name_hash(),
                         our_info,
                         ci_rx,
                         &config,

--- a/src/service.rs
+++ b/src/service.rs
@@ -301,7 +301,7 @@ impl Service {
             our_sk: self.our_sk.clone(),
         };
 
-        if self.listeners.has_public_addrs() {
+        if self.listeners.has_public_addrs() || self.config.rendezvous_connections_disabled() {
             future::ok(priv_conn_info).into_boxed()
         } else {
             self.with_p2p_connection_info(priv_conn_info)

--- a/src/tests/service_tests.rs
+++ b/src/tests/service_tests.rs
@@ -8,7 +8,6 @@
 // Software.
 
 use config::{DevConfigSettings, PeerInfo};
-use env_logger;
 use future_utils::bi_channel;
 use futures::stream;
 use priv_prelude::*;
@@ -242,31 +241,6 @@ mod direct_connections {
         let service2_peer = PeerInfo::new(unwrap!(service2_peer.addr()), service1.public_id());
         assert!(service2.bootstrap_cache().peers().contains(&service2_peer));
     }
-}
-
-// None of the services in this test has listeners, therefore peer-to-peer connections are made.
-#[test]
-fn p2p_connections_on_localhost() {
-    let _ = env_logger::init();
-
-    let mut event_loop = unwrap!(Core::new());
-
-    let config = unwrap!(ConfigFile::new_temporary());
-    let service1 = service_with_config(&mut event_loop, config);
-
-    let config = unwrap!(ConfigFile::new_temporary());
-    let service2 = service_with_config(&mut event_loop, config);
-
-    let (ci_channel1, ci_channel2) = bi_channel::unbounded();
-    let connect = service1
-        .connect(ci_channel1)
-        .join(service2.connect(ci_channel2))
-        .with_timeout(Duration::from_secs(10), &event_loop.handle())
-        .map(|res_opt| unwrap!(res_opt, "p2p connection timed out"));
-
-    let (service1_peer, service2_peer) = unwrap!(event_loop.run(connect));
-    assert_eq!(service1_peer.public_id(), &service2.public_id());
-    assert_eq!(service2_peer.public_id(), &service1.public_id());
 }
 
 #[test]


### PR DESCRIPTION
Make sure Peer is not dropped after connection attempt. Otherwise connections might be terminated immaturely. Also, during `connect_all()` Crust was not doing a proper connection handshake, which was expected by connection demultiplexer. This PR makes sure `connect_all()` executes the whole connection handshake process, otherwise demux will discard those connections cause it's waiting for HandhsakeMessage::Connect.