### PR TITLE
Use Docker for Building on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,23 +17,8 @@ branches:
 cache:
   cargo: true
 before_script:
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-      set -x;
-      curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh;
-      bash cargo_install.sh cargo-prune;
-    elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-      set x;
-      version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g');
-      docker pull jacderida/crust-ci:$version;
-    fi
+  - ./scripts/pre-build.sh
 script:
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-      set -x;
-      cargo test --release --verbose;
-    elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-      set x;
-      version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g');
-      docker run --rm -v "$PWD":/usr/src/crust jacderida/crust-ci:$version;
-    fi
+  - ./scripts/build.sh
 before_cache:
   - cargo prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,30 +18,22 @@ cache:
   cargo: true
 before_script:
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-      (
-        set -x;
-        curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
-        bash cargo_install.sh cargo-prune
-      );
+      set -x;
+      curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh;
+      bash cargo_install.sh cargo-prune;
     elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-      (
-        set x;
-        version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g')
-        docker pull jacderida/crust-ci:$version
-      );
+      set x;
+      version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g');
+      docker pull jacderida/crust-ci:$version;
     fi
 script:
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-      (
-        set -x;
-        cargo test --release --verbose
-      );
+      set -x;
+      cargo test --release --verbose;
     elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-      (
-        set x;
-        version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g')
-        docker run --rm -v "$PWD":/usr/src/crust jacderida/crust-ci:$version
-      );
+      set x;
+      version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g');
+      docker run --rm -v "$PWD":/usr/src/crust jacderida/crust-ci:$version;
     fi
 before_cache:
   - cargo prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
         set x;
         version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g')
         docker pull jacderida/crust-ci:$version
-      )
+      );
     fi
 script:
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
@@ -41,7 +41,7 @@ script:
         set x;
         version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g')
         docker run --rm -v "$PWD":/usr/src/crust jacderida/crust-ci:$version
-      )
+      );
     fi
 before_cache:
   - cargo prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,35 @@ sudo: false
 branches:
   only:
     - master
+    - docker
 cache:
   cargo: true
 before_script:
-  - curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
-  - bash cargo_install.sh cargo-prune;
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+      (
+        set -x;
+        curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
+        bash cargo_install.sh cargo-prune
+      );
+    elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      (
+        set x;
+        version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g')
+        docker pull jacderida/crust-ci:$version
+      )
+    fi
 script:
-  - set -x;
-    cargo test --release --verbose
+  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+      (
+        set -x;
+        cargo test --release --verbose
+      );
+    elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      (
+        set x;
+        version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g')
+        docker run --rm -v "$PWD":/usr/src/crust jacderida/crust-ci:$version
+      )
+    fi
 before_cache:
   - cargo prune

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,12 @@ env:
 os:
   - linux
   - osx
+services:
+  - docker
 language: rust
 rust:
   - 1.29.2
-sudo: false
+sudo: required
 branches:
   only:
     - master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust:1.29.2
+
+RUN apt-get update -y && mkdir /target
+
+WORKDIR /usr/src/crust
+COPY . .
+RUN cargo build --release --verbose --target-dir /target
+
+CMD cargo test --release --verbose --target-dir /target

--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,10 @@ build-container:
 	docker build -t maidsafe/crust:${VERSION} .
 
 push-container: build-container
-	docker pull maidsafe/crust:${VERSION}
-
-pull-container:
 	docker push maidsafe/crust:${VERSION}
 
-run-container-build: pull-container
+run-container-build: build-container
 	docker run --rm -v "${PWD}":/usr/src/crust maidsafe/crust:${VERSION}
 
-run-container-build-debug: pull-container
+run-container-build-debug: build-container
 	docker run --rm -it -v "${PWD}":/usr/src/crust maidsafe/crust:${VERSION} /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,17 @@ VERSION := $(shell cat Cargo.toml | grep "^version" | awk '{ print $$3 }' | sed 
 PWD := $(shell echo $$PWD)
 
 build-container:
-	docker rmi jacderida/crust:${VERSION}
-	docker build -t jacderida/crust:${VERSION} .
+	docker rmi -f maidsafe/crust:${VERSION}
+	docker build -t maidsafe/crust:${VERSION} .
 
 push-container: build-container
-	docker push jacderida/crust:${VERSION}
+	docker pull maidsafe/crust:${VERSION}
 
-run-container-build:
-	docker run --rm -v "${PWD}":/usr/src/crust jacderida/crust:${VERSION}
+pull-container:
+	docker push maidsafe/crust:${VERSION}
+
+run-container-build: pull-container
+	docker run --rm -v "${PWD}":/usr/src/crust maidsafe/crust:${VERSION}
+
+run-container-build-debug: pull-container
+	docker run --rm -it -v "${PWD}":/usr/src/crust maidsafe/crust:${VERSION} /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+SHELL:=/bin/bash
+VERSION := $(shell cat Cargo.toml | grep "^version" | awk '{ print $$3 }' | sed 's/\"//g')
+PWD := $(shell echo $$PWD)
+
+build-container:
+	docker rmi jacderida/crust:${VERSION}
+	docker build -t jacderida/crust:${VERSION} .
+
+push-container: build-container
+	docker push jacderida/crust:${VERSION}
+
+run-container-build:
+	docker run --rm -v "${PWD}":/usr/src/crust jacderida/crust:${VERSION}

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ With that environment setup, on Linux or OSX, it should be as simple as cloning 
 
 ### Using Docker
 
-This repository also provides a Dockerfile that defines a container that has the prerequisites necessary for building Crust. To run this, install Docker on your host machine, then either pull the container or build it on the host. If you want to build it, there's a utility Makefile with a `build-container` target. If you're happy to work with the existing container, simply run `make run-container-build`, which will pull in the container then run it; this will build the current code and run the tests.
+This repository also provides a Dockerfile that defines a container with the prerequisites necessary for building Crust. To run this, install Docker on your host machine, then build the container on your host; there's a utility Makefile with a `build-container` target. You can also run `make run-container-build` to build and run the container in one step.
 
-If you want to debug a build or get access to the artifacts produced, do the following:
+If you want to debug a build or access the artifacts produced from the build, do the following:
 
 * Run `make run-container-build-debug` from your host; this will give you shell access in the container.
 * Run `cargo test --release --verbose` from the shell in the container.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,35 @@ The network encrypts everything handed to it for transportation automatically. W
 ### Bootstrap cache
 Bootstrap caching enhances the concept of using genesis nodes (hard-coded addresses) for initial vault detection by dynamically creating a list of nodes which are directly reachable without the need to hole-punch. This list is appended and pruned as nodes connect/disconnect to the network so is always kept up-to-date.
 
+<a name="building"></a>
+## Building from Source
+
+### Using Cargo
+As per any standard Rust library, Crust can be built using Cargo. This involves setting up a [Rust installation](https://www.rust-lang.org/en-US/install.html) on the target environment and platform. In addition to this, a GCC environment is also required. Setup of that depends on the platform:
+
+* Linux: install the `build-essentials` package for your distribution
+* OSX: install the 'Command Line Tools for XCode' package from the Apple Developer site or use [Homebrew](https://formulae.brew.sh/formula/gcc)
+* Windows: get an installation of MinGW via [MSYS2](http://www.msys2.org/) or [Git Bash for Windows](https://gitforwindows.org/)
+
+On Windows it is also possible to build with the Microsoft C++ toolchain, but using MinGW is the preferred method. Setting up the Microsoft C++ environment is beyond the scope of this document.
+
+With that environment setup, on Linux or OSX, it should be as simple as cloning this repository then running `cargo build`. On Windows, it's slightly different:
+
+* Use `rustup` to install the GNU target: `rustup target add x86_64-pc-windows-gnu`
+* Specify this target when invoking Cargo: `cargo build --target x86_64-pc-windows-gnu`
+
+### Using Docker
+
+This repository also provides a Dockerfile that defines a container that has the prerequisites necessary for building Crust. To run this, install Docker on your host machine, then either pull the container or build it on the host. If you want to build it, there's a utility Makefile with a `build-container` target. If you're happy to work with the existing container, simply run `make run-container-build`, which will pull in the container then run it; this will build the current code and run the tests.
+
+If you want to debug a build or get access to the artifacts produced, do the following:
+
+* Run `make run-container-build-debug` from your host; this will give you shell access in the container.
+* Run `cargo test --release --verbose` from the shell in the container.
+* With the shell access in the container, you can debug any problems with the build.
+* If you need access to the build artifacts, these will be available in the `target` directory on your host, since the current directory is mounted in as a shared volume.
+* Exit the container to return back to the host shell.
+
 <a name="license"></a>
 ## License
 This Crust library is dual-licensed under the Modified BSD ( [LICENSE-BSD](https://opensource.org/licenses/BSD-3-Clause)) or the MIT license ( [LICENSE-MIT](http://opensource.org/licenses/MIT)) at your option.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -x;
+
+if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+    cargo test --release --verbose;
+elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+    version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g');
+    docker run --rm -v "$PWD":/usr/src/crust jacderida/crust-ci:$version;
+fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,5 +6,5 @@ if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
     cargo test --release --verbose;
 elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
     version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g');
-    docker run --rm -v "$PWD":/usr/src/crust jacderida/crust-ci:$version;
+    docker run --rm -v "$PWD":/usr/src/crust jacderida/crust:$version;
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -6,5 +6,5 @@ if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
     cargo test --release --verbose;
 elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
     version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g');
-    docker run --rm -v "$PWD":/usr/src/crust jacderida/crust:$version;
+    docker run --rm -v "$PWD":/usr/src/crust maidsafe/crust:$version;
 fi

--- a/scripts/pre-build.sh
+++ b/scripts/pre-build.sh
@@ -7,5 +7,5 @@ if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
     bash cargo_install.sh cargo-prune
 elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
     version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g')
-    docker pull jacderida/crust-ci:$version
+    docker pull jacderida/crust:$version
 fi

--- a/scripts/pre-build.sh
+++ b/scripts/pre-build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -x
+
+if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+    curl -sSL https://github.com/maidsafe/QA/raw/master/travis/cargo_install.sh > cargo_install.sh
+    bash cargo_install.sh cargo-prune
+elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+    version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g')
+    docker pull jacderida/crust-ci:$version
+fi

--- a/scripts/pre-build.sh
+++ b/scripts/pre-build.sh
@@ -7,5 +7,5 @@ if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
     bash cargo_install.sh cargo-prune
 elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
     version=$(cat Cargo.toml | grep "^version" | awk '{ print $3 }' | sed 's/\"//g')
-    docker pull jacderida/crust:$version
+    docker pull maidsafe/crust:$version
 fi


### PR DESCRIPTION
@S-Coyle has advised submitting this PR.

We have longer term plans to use Docker as a central part of our Travis and internal build processes, and Crust was a simple place we could prove the concept. There are several reasons for using Docker:

* An identical environment both internally and on the Travis side
* Minimises Travis files to a simple docker pull, docker run setup (only applies to Linux at this time)
* Gives us back more control by defining our environments inside the container
* Developers can use the Docker configuration to reproduce build and CI problems
* Reduced build times due to dependencies being cached in the containers

Points of interest:

* Dockerfile that defines an environment for building Crust. It bases from the [official Rust container](https://hub.docker.com/_/rust/) to minimise setup.
* A utility Makefile for building and running the container easily.
* The README has been updated to include instructions for building from source. It seemed kind of weird to provide some information for building with Docker but have no information for a 'normal' build, so I also added some info for that. Those instructions weren't intended to be a step by step guide, but rather some general helpful information.
* The multi line Bash scripts are refactored out into files. You can notice there are unfortunately several commits in this PR where I was trying to change the Travis configuration to get it to work with multi line scripts, but none of these combinations worked. It does make the Travis process slightly more convoluted to understand, but in any case, I actually prefer maintaining a script file rather than inline scripts in a YAML document.

If we were only running the build on Linux we could remove all the Rust setup from the Travis file, but we need to retain that for OSX. Sadly that adds cruft to the Linux build that isn't necessary, but having an OSX definition in the same file means we can't get around this.
