### PR TITLE
resolves #1075: service discovery improvements

### DIFF
--- a/src/main/config_handler.rs
+++ b/src/main/config_handler.rs
@@ -33,8 +33,12 @@ pub struct Config {
     /// can specify this value as true, which will force crust to add the above `tcp_acceptor_port`
     /// to one of our externally reachable endpoint.
     pub force_acceptor_port_in_ext_ep: bool,
-    /// Port for service discovery on local network
+    /// Port for service discovery on local network. This port is used to broadcast messages to.
     pub service_discovery_port: Option<u16>,
+    /// You can configure service discovery server to listen on a separate port. This becomes
+    /// useful when you want to run multiple instances of Crust on the same machine.
+    /// By default it will use the same as `service_discovery_port` value.
+    pub service_discovery_listener_port: Option<u16>,
     /// File for bootstrap cache
     pub bootstrap_cache_name: Option<String>,
     /// Whitelisted nodes who are allowed to bootstrap off us or to connect to us
@@ -64,6 +68,7 @@ impl Default for Config {
             tcp_acceptor_port: None,
             force_acceptor_port_in_ext_ep: false,
             service_discovery_port: None,
+            service_discovery_listener_port: None,
             bootstrap_cache_name: None,
             whitelisted_node_ips: None,
             whitelisted_client_ips: None,

--- a/src/main/service.rs
+++ b/src/main/service.rs
@@ -140,10 +140,14 @@ impl<UID: Uid> Service<UID> {
     /// broadcasts.
     pub fn start_service_discovery(&mut self) {
         let our_listeners = self.our_listeners.clone();
-        let port = unwrap!(self.config.lock())
+        let remote_port = unwrap!(self.config.lock())
             .cfg
             .service_discovery_port
             .unwrap_or(SERVICE_DISCOVERY_DEFAULT_PORT);
+        let listener_port = unwrap!(self.config.lock())
+            .cfg
+            .service_discovery_listener_port
+            .unwrap_or(remote_port);
 
         let _ = self.post(move |core, poll| {
             if core.get_state(SERVICE_DISCOVERY_TOKEN).is_none() {
@@ -152,7 +156,8 @@ impl<UID: Uid> Service<UID> {
                     poll,
                     our_listeners,
                     SERVICE_DISCOVERY_TOKEN,
-                    port,
+                    listener_port,
+                    remote_port,
                 ) {
                     debug!("Could not start ServiceDiscovery: {:?}", e);
                 }

--- a/src/service_discovery/mod.rs
+++ b/src/service_discovery/mod.rs
@@ -20,9 +20,8 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::io::ErrorKind;
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::rc::Rc;
-use std::str::FromStr;
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::u16;
@@ -47,18 +46,25 @@ pub struct ServiceDiscovery {
 }
 
 impl ServiceDiscovery {
+    /// Starts service discovery process.
+    ///
+    /// # Args
+    ///
+    /// - listener_port - port we will be litening for incoming service discovery requests.
+    /// - remote_port - port we will broadcasting service discovery requests to.
     pub fn start(
         core: &mut Core,
         poll: &Poll,
         our_listeners: Arc<Mutex<Vec<SocketAddr>>>,
         token: Token,
-        port: u16,
+        listener_port: u16,
+        remote_port: u16,
     ) -> Result<(), ServiceDiscoveryError> {
-        let udp_socket = get_socket(port)?;
+        let udp_socket = UdpSocket::bind(&ipv4_addr(0, 0, 0, 0, listener_port))?;
         udp_socket.set_broadcast(true)?;
 
         let guid = rand::random();
-        let remote_addr = SocketAddr::from_str(&format!("255.255.255.255:{}", port))?;
+        let remote_addr = ipv4_addr(255, 255, 255, 255, remote_port);
 
         let service_discovery = ServiceDiscovery {
             token,
@@ -211,18 +217,8 @@ impl State for ServiceDiscovery {
     }
 }
 
-fn get_socket(mut port: u16) -> Result<UdpSocket, ServiceDiscoveryError> {
-    let mut res;
-    loop {
-        let bind_addr = SocketAddr::from_str(&format!("0.0.0.0:{}", port))?;
-        res = UdpSocket::bind(&bind_addr).map_err(From::from);
-        if res.is_ok() || port == u16::MAX {
-            break;
-        }
-        port += 1;
-    }
-
-    res
+fn ipv4_addr(a: u8, b: u8, c: u8, d: u8, port: u16) -> SocketAddr {
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(a, b, c, d), port))
 }
 
 #[cfg(test)]
@@ -256,7 +252,14 @@ mod tests {
             unwrap!(
                 el0.send(CoreMessage::new(move |core, poll| {
                     unwrap!(
-                        ServiceDiscovery::start(core, poll, listeners_0_clone, token_0, 65_530),
+                        ServiceDiscovery::start(
+                            core,
+                            poll,
+                            listeners_0_clone,
+                            token_0,
+                            65_530,
+                            65_530
+                        ),
                         "Could not spawn ServiceDiscovery_0"
                     );
                 })),
@@ -288,7 +291,7 @@ mod tests {
             unwrap!(
                 el1.send(CoreMessage::new(move |core, poll| {
                     unwrap!(
-                        ServiceDiscovery::start(core, poll, listeners_1, token_1, 65_530),
+                        ServiceDiscovery::start(core, poll, listeners_1, token_1, 0, 65_530),
                         "Could not spawn ServiceDiscovery_1"
                     );
                 })),

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -87,20 +87,18 @@ fn bootstrap_two_services_and_exchange_messages() {
 // Note: if this test fails, make sure that a firewall on your system allows UDP broadcasts
 #[test]
 fn bootstrap_two_services_using_service_discovery() {
-    let service_discovery_port = gen_service_discovery_port();
-
-    let mut config = gen_config();
-    config.service_discovery_port = Some(service_discovery_port);
+    let mut config0 = gen_config();
+    let service0_discovery_port = gen_service_discovery_port();
+    config0.service_discovery_listener_port = Some(service0_discovery_port);
 
     let (event_tx0, event_rx0) = get_event_sender();
-    let mut service0 = unwrap!(Service::with_config(
-        event_tx0,
-        config.clone(),
-        rand::random()
-    ));
+    let mut service0 = unwrap!(Service::with_config(event_tx0, config0, rand::random()));
 
     let (event_tx1, event_rx1) = get_event_sender();
-    let mut service1 = unwrap!(Service::with_config(event_tx1, config, rand::random()));
+    let mut config1 = gen_config();
+    config1.service_discovery_listener_port = Some(gen_service_discovery_port());
+    config1.service_discovery_port = Some(service0_discovery_port);
+    let mut service1 = unwrap!(Service::with_config(event_tx1, config1, rand::random()));
 
     unwrap!(service1.start_listening_tcp());
     let _ = expect_event!(event_rx1, Event::ListenerStarted(port) => port);


### PR DESCRIPTION
* Fixed UDP read to receive all packets until the socket blocks,
* added ability to run service discovery listener on a separate port.