### PR TITLE
resolves #1086: configurable external reachability test

### DIFF
--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -501,7 +501,7 @@ fn main() {
                             continue;
                         }
                     };
-                    unwrap!(unwrap!(service.lock()).connect(our_info, their_info));
+                    unwrap!(unwrap!(service.lock()).connect(our_info, their_info, false));
                 }
                 UserCommand::Send(peer_index, message) => {
                     let network = unwrap!(network.lock());

--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -19,7 +19,7 @@ pub enum Message<UID> {
     EchoAddrReq(PublicEncryptKey),
     EchoAddrResp(common::SocketAddr),
     ChooseConnection,
-    Connect(UID, NameHash, PublicEncryptKey),
+    Connect(UID, NameHash, ExternalReachability, PublicEncryptKey),
     Data(Vec<u8>),
 }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -35,6 +35,8 @@ pub enum CrustUser {
     Client,
 }
 
+/// Crust might optionally test, if peers are reachable directly. This struct carries information
+/// required to execute the test.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum ExternalReachability {
     NotRequired,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,12 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-//! #crust
+//! # crust
+//!
 //! Reliable peer-to-peer network connections in Rust with NAT traversal.
+//! See [`Service`] documentation which is the main structure to use crust services.
+//!
+//! [`Service`]: struct.Service.html
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/maidsafe/QA/master/Images/maidsafe_logo.png",

--- a/src/main/connect/mod.rs
+++ b/src/main/connect/mod.rs
@@ -10,7 +10,7 @@
 mod exchange_msg;
 
 use self::exchange_msg::ExchangeMsg;
-use crate::common::{CoreTimer, CrustUser, NameHash, PeerInfo, State, Uid};
+use crate::common::{CoreTimer, CrustUser, ExternalReachability, NameHash, PeerInfo, State, Uid};
 use crate::main::bootstrap;
 use crate::main::{
     ActiveConnection, ConnectionCandidate, ConnectionMap, CrustConfig, CrustError, Event,
@@ -41,6 +41,7 @@ pub struct Connect<UID: Uid> {
     event_tx: crate::CrustEventSender<UID>,
     our_pk: PublicEncryptKey,
     config: CrustConfig,
+    ext_reachability: ExternalReachability,
 }
 
 impl<UID: Uid> Connect<UID> {
@@ -55,6 +56,7 @@ impl<UID: Uid> Connect<UID> {
         our_pk: PublicEncryptKey,
         our_sk: &SecretEncryptKey,
         config: CrustConfig,
+        ext_reachability: ExternalReachability,
     ) -> crate::Res<()> {
         let their_id = their_ci.id;
         let their_direct = their_ci.for_direct;
@@ -78,6 +80,7 @@ impl<UID: Uid> Connect<UID> {
             event_tx,
             our_pk,
             config,
+            ext_reachability,
         }));
 
         state.borrow_mut().self_weak = Rc::downgrade(&state);
@@ -136,6 +139,7 @@ impl<UID: Uid> Connect<UID> {
             self.cm.clone(),
             self.our_pk,
             shared_key,
+            self.ext_reachability.clone(),
             Box::new(handler),
         ) {
             let _ = self.children.insert(child);
@@ -311,6 +315,7 @@ mod tests {
                 our_pk,
                 &our_sk,
                 config,
+                ExternalReachability::NotRequired,
             ));
 
             let connect_state_token = Token(0);

--- a/src/main/connection_listener/check_reachability.rs
+++ b/src/main/connection_listener/check_reachability.rs
@@ -23,6 +23,8 @@ const CHECK_REACHABILITY_TIMEOUT_SEC: u64 = 3;
 
 pub type Finish<T> = Box<FnMut(&mut EventLoopCore, &Poll, Token, Result<T, ()>)>;
 
+/// Does a simple TCP connect to the given address to check, if it's publicly reachable.
+/// This state will transit arbitrary user data to the finish callback.
 pub struct CheckReachability<T> {
     token: Token,
     socket: TcpSock,

--- a/src/main/connection_listener/mod.rs
+++ b/src/main/connection_listener/mod.rs
@@ -433,7 +433,12 @@ mod tests {
         unwrap!(sock.set_decrypt_ctx(DecryptContext::authenticated(shared_key.clone())));
         unwrap!(el.register(&sock, SOCKET_TOKEN, Ready::writable(), PollOpt::edge()));
 
-        let message = Message::Connect(our_uid, name_hash, our_pk);
+        let message = Message::Connect(
+            our_uid,
+            name_hash,
+            ExternalReachability::NotRequired,
+            our_pk,
+        );
 
         let mut events = Events::with_capacity(16);
         'event_loop: loop {
@@ -454,7 +459,7 @@ mod tests {
                         if ev.readiness().is_readable() {
                             let msg: Message<UniqueId> = unwrap!(unwrap!(sock.read()));
                             let their_uid = match msg {
-                                Message::Connect(peer_uid, peer_hash, their_pk) => {
+                                Message::Connect(peer_uid, peer_hash, _, their_pk) => {
                                     assert_eq!(peer_uid, listener.uid);
                                     assert_eq!(peer_hash, NAME_HASH);
                                     assert_eq!(their_pk, listener.pub_key);

--- a/src/main/service.rs
+++ b/src/main/service.rs
@@ -49,6 +49,35 @@ const DISABLE_NAT: bool = true;
 
 /// A structure representing all the Crust services. This is the main object through which crust is
 /// used.
+///
+/// You can construct `Service` using [`try_new`] which searches for config file in default location
+/// or [`with_config`], if you want to provide an in memory config.
+///
+/// In the terms of networking `Service` exposes both server and client functionality. Meaning
+/// it will listen for incoming connections and establish ones itself.
+///
+/// You can use `Service` to connect with remote peers. There's two ways to do this:
+///
+/// 1. [`bootstrap`] to some known peers or the ones discovered on LAN,
+/// 2. [`connect`] to the peer whose contacts you already have.
+///
+/// [`bootstrap`] and [`connect`] will optionally check, if you are able to connect to peer via
+/// it's public IP. This is called external reachability test. You can ask to only connect to peers
+/// that are reachable on the Internet directly.
+///
+/// You also have to explicilty enable connection listening:
+///
+/// 1. to accept bootstrapping peers, call [`set_accept_bootstrap`],
+/// 2. to accept incoming connections via [`connect`], call [`start_listening_tcp`],
+/// 2. to accept incoming peers via service discovery on LAN, call [`set_service_discovery_listen`].
+///
+/// [`try_new`]: struct.Service.html#method.try_new
+/// [`with_config`]: struct.Service.html#method.with_config
+/// [`connect`]: struct.Service.html#method.connect
+/// [`bootstrap`]: struct.Service.html#method.start_bootstrap
+/// [`set_accept_bootstrap`]: struct.Service.html#method.set_accept_bootstrap
+/// [`start_listening_tcp`]: struct.Service.html#method.set_listening_tcp
+/// [`set_service_discovery_listen`]: struct.Service.html#method.set_service_discovery_listen
 pub struct Service<UID: Uid> {
     config: CrustConfig,
     cm: ConnectionMap<UID>,
@@ -64,7 +93,7 @@ pub struct Service<UID: Uid> {
 
 impl<UID: Uid> Service<UID> {
     /// Construct a service. `event_tx` is the sending half of the channel which crust will send
-    /// notifications on.
+    /// notifications on. Can fail, if can't read config file successfully.
     pub fn try_new(event_tx: crate::CrustEventSender<UID>, our_uid: UID) -> crate::Res<Self> {
         Service::with_config(event_tx, config_handler::read_config_file()?, our_uid)
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -107,7 +107,7 @@ fn bootstrap_two_services_and_exchange_messages() {
     let (event_tx1, event_rx1) = get_event_sender();
     let mut service1 = unwrap!(Service::with_config(event_tx1, config1, rand::random()));
 
-    unwrap!(service1.start_bootstrap(HashSet::new(), CrustUser::Client));
+    unwrap!(service1.start_bootstrap(HashSet::new(), false));
 
     let peer_id0 = expect_event!(event_rx1, Event::BootstrapConnect(peer_id, _) => peer_id);
     assert_eq!(peer_id0, service0.id());
@@ -160,7 +160,7 @@ fn bootstrap_two_services_using_service_discovery() {
     unwrap!(service0.set_accept_bootstrap(true));
 
     service1.start_service_discovery();
-    unwrap!(service1.start_bootstrap(HashSet::new(), CrustUser::Client));
+    unwrap!(service1.start_bootstrap(HashSet::new(), false));
 
     let peer_id0 = expect_event!(event_rx1, Event::BootstrapConnect(peer_id, _) => peer_id);
     assert_eq!(peer_id0, service0.id());
@@ -192,7 +192,7 @@ fn bootstrap_with_multiple_contact_endpoints() {
 
     let (event_tx1, event_rx1) = get_event_sender();
     let mut service1 = unwrap!(Service::with_config(event_tx1, config1, rand::random()));
-    unwrap!(service1.start_bootstrap(HashSet::new(), CrustUser::Client));
+    unwrap!(service1.start_bootstrap(HashSet::new(), false));
 
     unwrap!(service1.start_listening_tcp());
     let _ = expect_event!(event_rx1, Event::ListenerStarted(port) => port);
@@ -222,7 +222,7 @@ fn bootstrap_with_skipped_external_reachability_test() {
 
     let (event_tx1, event_rx1) = get_event_sender();
     let mut service1 = unwrap!(Service::with_config(event_tx1, config1, rand::random()));
-    unwrap!(service1.start_bootstrap(HashSet::new(), CrustUser::Node));
+    unwrap!(service1.start_bootstrap(HashSet::new(), true));
 
     let peer_id0 = expect_event!(event_rx1, Event::BootstrapConnect(peer_id, _) => peer_id);
     assert_eq!(peer_id0, service0.id());
@@ -259,7 +259,7 @@ fn bootstrap_with_blacklist() {
     let mut service1 = unwrap!(Service::with_config(event_tx1, config1, rand::random()));
     let mut blacklist = HashSet::new();
     let _ = blacklist.insert(blacklisted_address.addr);
-    unwrap!(service1.start_bootstrap(blacklist, CrustUser::Client));
+    unwrap!(service1.start_bootstrap(blacklist, false));
 
     unwrap!(service1.start_listening_tcp());
     let _ = expect_event!(event_rx1, Event::ListenerStarted(port) => port);
@@ -293,7 +293,7 @@ fn bootstrap_fails_only_blacklisted_contact() {
 
     let mut blacklist = HashSet::new();
     let _ = blacklist.insert(blacklisted_address.addr);
-    unwrap!(service.start_bootstrap(blacklist, CrustUser::Client));
+    unwrap!(service.start_bootstrap(blacklist, false));
 
     expect_event!(event_rx, Event::BootstrapFailed);
 
@@ -309,7 +309,7 @@ fn bootstrap_fails_if_there_are_no_contacts() {
     let (event_tx, event_rx) = get_event_sender();
     let mut service = unwrap!(Service::with_config(event_tx, config, rand::random()));
 
-    unwrap!(service.start_bootstrap(HashSet::new(), CrustUser::Client));
+    unwrap!(service.start_bootstrap(HashSet::new(), false));
     expect_event!(event_rx, Event::BootstrapFailed);
 }
 
@@ -327,7 +327,7 @@ fn bootstrap_timeouts_if_there_are_only_invalid_contacts() {
     let (event_tx, event_rx) = get_event_sender();
     let mut service = unwrap!(Service::with_config(event_tx, config, rand::random()));
 
-    unwrap!(service.start_bootstrap(HashSet::new(), CrustUser::Client));
+    unwrap!(service.start_bootstrap(HashSet::new(), false));
     expect_event!(event_rx, Event::BootstrapFailed);
 }
 
@@ -347,7 +347,7 @@ fn drop_disconnects() {
     let (event_tx_1, event_rx_1) = get_event_sender();
     let mut service_1 = unwrap!(Service::with_config(event_tx_1, config_1, rand::random()));
 
-    unwrap!(service_1.start_bootstrap(HashSet::new(), CrustUser::Client));
+    unwrap!(service_1.start_bootstrap(HashSet::new(), false));
 
     let peer_id_0 = expect_event!(event_rx_1, Event::BootstrapConnect(peer_id, _) => peer_id);
     expect_event!(event_rx_0, Event::BootstrapAccept(_peer_id, _));
@@ -506,7 +506,7 @@ fn drop_peer_when_no_message_received_within_inactivity_period() {
     let (event_tx, event_rx) = get_event_sender();
     let mut service = unwrap!(Service::with_config(event_tx, config, rand::random()));
 
-    unwrap!(service.start_bootstrap(HashSet::new(), CrustUser::Client));
+    unwrap!(service.start_bootstrap(HashSet::new(), false));
     let peer_id = expect_event!(event_rx, Event::BootstrapConnect(peer_id, _) => peer_id);
 
     // The peer should drop after inactivity.
@@ -535,7 +535,7 @@ fn do_not_drop_peer_even_when_no_data_messages_are_exchanged_within_inactivity_p
     let (event_tx1, event_rx1) = get_event_sender();
     let mut service1 = unwrap!(Service::with_config(event_tx1, config1, rand::random()));
 
-    unwrap!(service1.start_bootstrap(HashSet::new(), CrustUser::Client));
+    unwrap!(service1.start_bootstrap(HashSet::new(), false));
     expect_event!(event_rx1, Event::BootstrapConnect(_peer_id, _));
     expect_event!(event_rx0, Event::BootstrapAccept(_peer_id, _));
 


### PR DESCRIPTION
1. External reachability test can now be executed during regular connections.
2. This test is optional and configured via parameter of `Service::connect()/start_bootstrap()` methods.