### PR TITLE
Split connect message

### DIFF
--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -23,14 +23,11 @@ pub enum Message<UID> {
     EchoAddrReq(PublicEncryptKey),
     EchoAddrResp(SocketAddr),
     ChooseConnection,
-    /// First connect handshake message which goes both ways: peer that initiates connection
-    /// sends this message to remote peer, which then responds with the same message, but its own
-    /// information.
-    /// When `Connect` is used as response message address list is ignored and can be empty. When
-    /// it is a request message, it should contain all the addresses we are listening on. Those
-    /// addresses will be used for external reachability test.
-    // TODO(povilas): consider splitting Connect into ConnectRequest and ConnectResponse
-    Connect(UID, NameHash, HashSet<SocketAddr>, PublicEncryptKey),
+    /// Send this message to initiate connection with remote peer. This message carries our ID,
+    /// network name hash, list of public IP:port pairs and our public key.
+    ConnectRequest(UID, NameHash, HashSet<SocketAddr>, PublicEncryptKey),
+    /// Response of accepted connection that carries remote peer's ID and network name hash.
+    ConnectResponse(UID, NameHash),
     Data(Vec<u8>),
 }
 

--- a/src/main/connect/exchange_msg.rs
+++ b/src/main/connect/exchange_msg.rs
@@ -83,7 +83,7 @@ impl<UID: Uid> ExchangeMsg<UID> {
             socket,
             cm,
             msg: Some((
-                Message::Connect(our_id, name_hash, our_global_direct_listeners, our_pk),
+                Message::ConnectRequest(our_id, name_hash, our_global_direct_listeners, our_pk),
                 0,
             )),
             shared_key,
@@ -108,7 +108,7 @@ impl<UID: Uid> ExchangeMsg<UID> {
 
     fn receive_response(&mut self, core: &mut EventLoopCore, poll: &Poll) {
         match self.socket.read::<Message<UID>>() {
-            Ok(Some(Message::Connect(their_uid, name_hash, _, _their_pk))) => {
+            Ok(Some(Message::ConnectResponse(their_uid, name_hash))) => {
                 if their_uid != self.expected_id || name_hash != self.expected_nh {
                     return self.handle_error(core, poll);
                 }

--- a/src/main/connection_listener/exchange_msg.rs
+++ b/src/main/connection_listener/exchange_msg.rs
@@ -129,7 +129,7 @@ impl<UID: Uid> ExchangeMsg<UID> {
                     Err(()) => self.terminate(core, poll),
                 }
             }
-            Ok(Some(Message::Connect(their_uid, name_hash, their_addrs, their_pk))) => {
+            Ok(Some(Message::ConnectRequest(their_uid, name_hash, their_addrs, their_pk))) => {
                 match self.validate_peer_uid(their_uid) {
                     Ok(their_uid) => {
                         self.handle_connect(core, poll, their_uid, name_hash, their_addrs, their_pk)
@@ -367,12 +367,7 @@ impl<UID: Uid> ExchangeMsg<UID> {
     fn send_connect_grant(&mut self, core: &mut EventLoopCore, poll: &Poll, their_uid: UID) {
         self.enter_handshaking_mode(their_uid);
         self.next_state = NextState::ConnectionCandidate(their_uid);
-        let msg = Message::Connect(
-            self.our_uid,
-            self.name_hash,
-            Default::default(),
-            self.our_pk,
-        );
+        let msg = Message::ConnectResponse(self.our_uid, self.name_hash);
         self.write(core, poll, Some((msg, 0)));
     }
 

--- a/src/main/connection_listener/mod.rs
+++ b/src/main/connection_listener/mod.rs
@@ -435,7 +435,7 @@ mod tests {
         unwrap!(sock.set_decrypt_ctx(DecryptContext::authenticated(shared_key.clone())));
         unwrap!(el.register(&sock, SOCKET_TOKEN, Ready::writable(), PollOpt::edge()));
 
-        let message = Message::Connect(our_uid, name_hash, Default::default(), our_pk);
+        let message = Message::ConnectRequest(our_uid, name_hash, Default::default(), our_pk);
 
         let mut events = Events::with_capacity(16);
         'event_loop: loop {
@@ -456,10 +456,9 @@ mod tests {
                         if ev.readiness().is_readable() {
                             let msg: Message<UniqueId> = unwrap!(unwrap!(sock.read()));
                             let their_uid = match msg {
-                                Message::Connect(peer_uid, peer_hash, _, their_pk) => {
+                                Message::ConnectResponse(peer_uid, peer_hash) => {
                                     assert_eq!(peer_uid, listener.uid);
                                     assert_eq!(peer_hash, NAME_HASH);
-                                    assert_eq!(their_pk, listener.pub_key);
 
                                     unwrap!(sock.set_encrypt_ctx(EncryptContext::authenticated(
                                         shared_key

--- a/src/main/mod.rs
+++ b/src/main/mod.rs
@@ -20,14 +20,9 @@ pub use self::error::CrustError;
 pub use self::event::Event;
 pub use self::service::Service;
 pub use self::types::{
-    ConfigWrapper, ConnectionId, ConnectionInfoResult, EventLoop, EventLoopCore,
-    PrivConnectionInfo, PubConnectionInfo,
+    ConfigWrapper, ConnectionId, ConnectionInfoResult, ConnectionMap, CrustConfig, EventLoop,
+    EventLoopCore, PrivConnectionInfo, PubConnectionInfo,
 };
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-
-pub type ConnectionMap<UID> = Arc<Mutex<HashMap<UID, ConnectionId>>>;
-pub type CrustConfig = Arc<Mutex<ConfigWrapper>>;
 
 mod active_connection;
 mod bootstrap;

--- a/src/main/types.rs
+++ b/src/main/types.rs
@@ -12,7 +12,9 @@ use crate::main::bootstrap::Cache as BootstrapCache;
 use crate::main::Config;
 use mio::Token;
 use safe_crypto::PublicEncryptKey;
+use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
 
 // ========================================================================================
 //                                     ConnectionId
@@ -125,3 +127,6 @@ pub type EventLoopCore = Core<BootstrapCache>;
 
 /// Handle to Crust event loop that owns `EventLoopCore`.
 pub type EventLoop = common::EventLoop<BootstrapCache>;
+
+pub type ConnectionMap<UID> = Arc<Mutex<HashMap<UID, ConnectionId>>>;
+pub type CrustConfig = Arc<Mutex<ConfigWrapper>>;


### PR DESCRIPTION
Before Crust used to use a single message to initiate connection and respond to such connection requests.
This lead to issues where response was carrying information that was not used at all. So segregating request/response messages is a better design and makes the code cleaner and easier to follow.
