### PR TITLE
Filter out duplicate PeerInfos from bootstrap's peer list

### DIFF
--- a/src/service_discovery/mod.rs
+++ b/src/service_discovery/mod.rs
@@ -18,6 +18,7 @@ use safe_crypto::PublicEncryptKey;
 use socket_collection::{Priority, SocketError, UdpSock};
 use std::any::Any;
 use std::cell::RefCell;
+use std::collections::HashSet;
 use std::marker::PhantomData;
 use std::net::SocketAddr;
 use std::rc::Rc;
@@ -31,7 +32,7 @@ enum DiscoveryMsg {
     Request {
         our_pk: PublicEncryptKey,
     },
-    Response(Vec<PeerInfo>),
+    Response(HashSet<PeerInfo>),
 }
 
 /// Acts both as service discovery server and client.
@@ -43,7 +44,7 @@ pub struct ServiceDiscovery<T> {
     listen: bool,
     our_listeners: Arc<Mutex<Vec<PeerInfo>>>,
     seek_peers_req: DiscoveryMsg,
-    observers: Vec<Sender<Vec<PeerInfo>>>,
+    observers: Vec<Sender<HashSet<PeerInfo>>>,
     our_pk: PublicEncryptKey,
     phantom: PhantomData<T>,
 }
@@ -109,7 +110,7 @@ impl<T: 'static> ServiceDiscovery<T> {
     }
 
     /// Register service discovery observer
-    pub fn register_observer(&mut self, obs: Sender<Vec<PeerInfo>>) {
+    pub fn register_observer(&mut self, obs: Sender<HashSet<PeerInfo>>) {
         self.observers.push(obs);
     }
 


### PR DESCRIPTION
Since #1105 was closed, here is the update in a new PR.

I added a function called `update_peers` in the bootstrap module. Instead of calling `.contains()` on a `Vec`, I turn the peers list into a `HashSet` of references (once O(n) + time to form `HashSet` instead of n-times O(n), or O(n^2)). I added unit tests to make sure that the list doesn't contain duplicates and that after the peers list is shuffled again, the hard-coded PeerInfos stay at the end, after the cached ones. I did not change `Vec<PeerInfo>` to `HashSet<PeerInfo>` in other places such as [this](https://github.com/maidsafe/crust/blob/master/src/service_discovery/mod.rs#L34) because I think it would have affected performance.

I hope this is OK 🍻 