### PR TITLE
Limit bootstrap peers

### DIFF
--- a/src/main/config_handler.rs
+++ b/src/main/config_handler.rs
@@ -42,6 +42,8 @@ pub struct Config {
     pub service_discovery_listener_port: Option<u16>,
     /// File for bootstrap cache
     pub bootstrap_cache_name: Option<OsString>,
+    /// Maximum number of peers the bootstrap cache can store
+    pub bootstrap_cache_limit: Option<usize>,
     /// Whitelisted nodes who are allowed to bootstrap off us or to connect to us
     pub whitelisted_node_ips: Option<HashSet<IpAddr>>,
     /// Whitelisted clients who are allowed to bootstrap off us
@@ -62,6 +64,7 @@ impl Default for Config {
             service_discovery_port: None,
             service_discovery_listener_port: None,
             bootstrap_cache_name: None,
+            bootstrap_cache_limit: None,
             whitelisted_node_ips: None,
             whitelisted_client_ips: None,
             network_name: None,

--- a/src/main/connection_listener/mod.rs
+++ b/src/main/connection_listener/mod.rs
@@ -265,7 +265,7 @@ mod tests {
         let el = unwrap!(common::spawn_event_loop(
             LISTENER_TOKEN + 1,
             Some("Connection Listener Test"),
-            || CrustData::new(BootstrapCache::new(None)),
+            || CrustData::new(BootstrapCache::new(None, None)),
         ));
 
         let (event_tx, event_rx) = mpsc::channel();

--- a/src/main/service.rs
+++ b/src/main/service.rs
@@ -128,11 +128,12 @@ impl<UID: Uid> Service<UID> {
         mc.add_peer_stuns(config.hard_coded_contacts.iter().cloned());
 
         let bootstrap_cache_file = config.bootstrap_cache_name.clone();
+        let bootstrap_cache_limit = config.bootstrap_cache_limit;
         let el = common::spawn_event_loop(
             EventToken::Unreserved as usize,
             Some(&format!("{:?}", our_uid)),
             move || {
-                let cache = BootstrapCache::new(bootstrap_cache_file);
+                let cache = BootstrapCache::new(bootstrap_cache_file, bootstrap_cache_limit);
                 cache.read_file();
                 let mut user_data = CrustData::new(cache);
                 user_data.config = ConfigWrapper::new(config);

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -106,7 +106,7 @@ pub fn test_core(bootstrap_cache: BootstrapCache) -> EventLoopCore<UniqueId> {
 /// Bootstrap cache on tmp directory with unique file name.
 pub fn test_bootstrap_cache() -> BootstrapCache {
     let cache_file = bootstrap_cache_tmp_file().into();
-    BootstrapCache::new(Some(cache_file))
+    BootstrapCache::new(Some(cache_file), None)
 }
 
 /// Constructs peer info with random generated public key.


### PR DESCRIPTION
I tackled point 1 and 2 from #1106 in this PR.

I added configurable bootstrap cache limit, implement trust metric for the peers by changing the container type to `HashMap<PeerInfo, Instant>` so that the most recently active peers are always kept in the cache. I used `time::Instant` because of the reasons I mentioned [in this comment](https://github.com/maidsafe/crust/issues/1106#issuecomment-455526538). Sorry I did not wait for your feedback, but this was the time I had allocated to work on this issue for today.

Partially resolves #1106