### PR TITLE
resolves #1118: accept encryption keys via Service constructor

### DIFF
--- a/src/common/message.rs
+++ b/src/common/message.rs
@@ -18,15 +18,17 @@ pub enum Message {
     Heartbeat,
     /// Carries a list of our listener addresses in case remote peer wants to check our
     /// external reachability.
-    BootstrapRequest(PeerId, NameHash, BootstrapperRole, PublicEncryptKey),
+    BootstrapRequest(PeerId, NameHash, BootstrapperRole),
+    /// Connection listener sends this message to the bootstrapee together with the peer ID that
+    /// runs connection listener.
     BootstrapGranted(PeerId),
     BootstrapDenied(BootstrapDenyReason),
     EchoAddrReq(PublicEncryptKey),
     EchoAddrResp(SocketAddr),
     ChooseConnection,
     /// Send this message to initiate connection with remote peer. This message carries our ID,
-    /// network name hash, list of public IP:port pairs and our public key.
-    ConnectRequest(PeerId, NameHash, HashSet<SocketAddr>, PublicEncryptKey),
+    /// network name hash ad list of public IP:port pairs.
+    ConnectRequest(PeerId, NameHash, HashSet<SocketAddr>),
     /// Response of accepted connection that carries remote peer's ID and network name hash.
     ConnectResponse(PeerId, NameHash),
     Data(Vec<u8>),

--- a/src/main/bootstrap/try_peer.rs
+++ b/src/main/bootstrap/try_peer.rs
@@ -11,7 +11,7 @@ use crate::common::{BootstrapDenyReason, BootstrapperRole, Message, NameHash, Pe
 use crate::main::{CrustData, EventLoopCore};
 use crate::PeerId;
 use mio::{Poll, PollOpt, Ready, Token};
-use safe_crypto::{PublicEncryptKey, SecretEncryptKey, SharedSecretKey};
+use safe_crypto::{SecretEncryptKey, SharedSecretKey};
 use socket_collection::{DecryptContext, EncryptContext, Priority, TcpSock};
 use std::any::Any;
 use std::cell::RefCell;
@@ -45,7 +45,6 @@ impl TryPeer {
         our_uid: PeerId,
         name_hash: NameHash,
         our_role: BootstrapperRole,
-        our_pk: PublicEncryptKey,
         our_sk: &SecretEncryptKey,
         finish: Finish,
     ) -> crate::Res<Token> {
@@ -66,10 +65,7 @@ impl TryPeer {
             token,
             peer,
             socket,
-            request: Some((
-                Message::BootstrapRequest(our_uid, name_hash, our_role, our_pk),
-                0,
-            )),
+            request: Some((Message::BootstrapRequest(our_uid, name_hash, our_role), 0)),
             finish,
             shared_key,
         };

--- a/src/main/connect/exchange_msg.rs
+++ b/src/main/connect/exchange_msg.rs
@@ -11,7 +11,7 @@ use crate::common::{Message, NameHash, State};
 use crate::main::{ConnectionId, CrustData, EventLoopCore};
 use crate::PeerId;
 use mio::{Poll, PollOpt, Ready, Token};
-use safe_crypto::{PublicEncryptKey, SharedSecretKey};
+use safe_crypto::SharedSecretKey;
 use socket_collection::{EncryptContext, Priority, TcpSock};
 use std::any::Any;
 use std::cell::RefCell;
@@ -44,7 +44,6 @@ impl ExchangeMsg {
         our_id: PeerId,
         expected_id: PeerId,
         name_hash: NameHash,
-        our_pk: PublicEncryptKey,
         shared_key: SharedSecretKey,
         our_global_direct_listeners: HashSet<SocketAddr>,
         finish: Finish,
@@ -78,7 +77,7 @@ impl ExchangeMsg {
             expected_nh: name_hash,
             socket,
             msg: Some((
-                Message::ConnectRequest(our_id, name_hash, our_global_direct_listeners, our_pk),
+                Message::ConnectRequest(our_id, name_hash, our_global_direct_listeners),
                 0,
             )),
             shared_key,

--- a/src/main/types.rs
+++ b/src/main/types.rs
@@ -12,7 +12,6 @@ use crate::main::bootstrap::Cache as BootstrapCache;
 use crate::main::Config;
 use crate::PeerId;
 use mio::Token;
-use safe_crypto::PublicEncryptKey;
 use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 
@@ -50,8 +49,6 @@ pub struct PrivConnectionInfo {
     pub id: PeerId,
     #[doc(hidden)]
     pub for_direct: Vec<SocketAddr>,
-    #[doc(hidden)]
-    pub our_pk: PublicEncryptKey,
 }
 
 impl PrivConnectionInfo {
@@ -61,7 +58,6 @@ impl PrivConnectionInfo {
         PubConnectionInfo {
             for_direct: self.for_direct.clone(),
             id: self.id,
-            our_pk: self.our_pk,
         }
     }
 }
@@ -76,8 +72,6 @@ pub struct PubConnectionInfo {
     pub id: PeerId,
     #[doc(hidden)]
     pub for_direct: Vec<SocketAddr>,
-    #[doc(hidden)]
-    pub our_pk: PublicEncryptKey,
 }
 
 impl PubConnectionInfo {

--- a/src/tests/utils.rs
+++ b/src/tests/utils.rs
@@ -15,7 +15,7 @@ use maidsafe_utilities::event_sender::{MaidSafeEventCategory, MaidSafeObserver};
 use mio_extras::channel::channel;
 use mio_extras::timer;
 use rand;
-use safe_crypto::{gen_encrypt_keypair, gen_sign_keypair};
+use safe_crypto::{gen_encrypt_keypair, gen_sign_keypair, SecretEncryptKey};
 use std::env;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -42,13 +42,14 @@ macro_rules! expect_event {
 }
 
 /// Generates random peer id.
-pub fn rand_peer_id() -> PeerId {
-    let (enc_pk, _enc_sk) = gen_encrypt_keypair();
+pub fn rand_peer_id_and_enc_sk() -> (PeerId, SecretEncryptKey) {
+    let (enc_pk, enc_sk) = gen_encrypt_keypair();
     let (sign_pk, _sign_sk) = gen_sign_keypair();
-    PeerId {
+    let id = PeerId {
         pub_sign_key: sign_pk,
         pub_enc_key: enc_pk,
-    }
+    };
+    (id, enc_sk)
 }
 
 pub fn get_event_sender() -> (crate::CrustEventSender, Receiver<Event>) {


### PR DESCRIPTION
This allows crust to reuse encryption keys from the upper layers.  Since
peer ID holds public key as well, a lot of messages, structures were
holding redundant copy of peer public key. This commit removes that as
well.