### PR TITLE
fix/example: remove external reachability requirement

### DIFF
--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -300,6 +300,7 @@ fn main() {
     let (peer_id, peer_sk) = new_peer_id();
     let mut service = unwrap!(Service::with_config(event_sender, config, peer_id, peer_sk));
     unwrap!(service.start_listening_tcp());
+    unwrap!(service.set_ext_reachability_test(false));
     service.start_service_discovery();
     let service = Arc::new(Mutex::new(service));
     let service_cloned = service.clone();


### PR DESCRIPTION
By default Crust requires nodes to be externally reachable. Although,
that can be disabled.  There's no point of this requirement in the
test, hence disabled it.