### PR TITLE
closes #835: linting

### DIFF
--- a/examples/crust_peer.rs
+++ b/examples/crust_peer.rs
@@ -300,6 +300,7 @@ fn main() {
     let (peer_id, peer_sk) = new_peer_id();
     let mut service = unwrap!(Service::with_config(event_sender, config, peer_id, peer_sk));
     unwrap!(service.start_listening_tcp());
+    unwrap!(service.set_ext_reachability_test(false));
     service.start_service_discovery();
     let service = Arc::new(Mutex::new(service));
     let service_cloned = service.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
     improper_ctypes,
     missing_docs,
     non_shorthand_field_patterns,
+    nonstandard_style,
     overflowing_literals,
     plugin_as_library,
     stable_features,


### PR DESCRIPTION
Deny `nonstandard-style`: https://doc.rust-lang.org/rustc/lints/groups.html