### PR TITLE
Fix bootstrap cache flushing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ crossbeam = "~0.2.10"
 get_if_addrs = "~0.5.3"
 igd = "~0.7.0"
 log = "~0.4.6"
-lru_time_cache = { git = "https://github.com/maidsafe/lru_time_cache", rev = "e6cfe58" }
+lru_time_cache = { git = "https://github.com/maidsafe/lru_time_cache", rev = "accc955" }
 maidsafe_utilities = "~0.17.0"
 mio = "~0.6.9"
 mio-extras = "~2.0.5"
@@ -33,6 +33,7 @@ unwrap = "~1.2.1"
 
 [dev-dependencies]
 clap = "~2.32.0"
+hamcrest2 = "~0.2.3"
 
 [[example]]
 bench = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,9 @@ extern crate serde_derive;
 extern crate unwrap;
 
 #[cfg(test)]
+#[macro_use]
+extern crate hamcrest2;
+#[cfg(test)]
 extern crate serde_json;
 #[cfg(test)]
 #[macro_use]

--- a/src/main/bootstrap/cache.rs
+++ b/src/main/bootstrap/cache.rs
@@ -69,11 +69,11 @@ impl Cache {
     pub fn read_file(&mut self) {
         match self.open_file() {
             Ok(file_handler) => {
-                let peers = file_handler.read_file().unwrap_or_else(|e| {
+                let mut peers = file_handler.read_file().unwrap_or_else(|e| {
                     info!("Failed to read bootstrap cache file: {}", e);
                     Default::default()
                 });
-                for peer in peers {
+                for peer in peers.drain(..).rev() {
                     let _ = self.peers.insert(peer.pub_key, peer);
                 }
             }
@@ -99,7 +99,7 @@ impl Cache {
     /// Writes bootstrap cache to disk.
     pub fn commit(&self) -> crate::Res<()> {
         let file_handler = self.open_file()?;
-        let peers: HashSet<PeerInfo> = self.peers.peek_iter().map(|(_, peer)| *peer).collect();
+        let peers: Vec<PeerInfo> = self.peers.peek_iter().map(|(_, peer)| *peer).collect();
         file_handler.write_file(&peers)?;
         Ok(())
     }
@@ -111,9 +111,9 @@ impl Cache {
         }
     }
 
-    /// Returns cached peers.
+    /// Returns cached peers in the most recently used order.
     /// Moves returned peers to the top of the cache.
-    pub fn peers(&mut self) -> (HashSet<PeerInfo>, HashSet<PeerInfo>) {
+    pub fn peers(&mut self) -> (Vec<PeerInfo>, HashSet<PeerInfo>) {
         let expired: HashSet<_> = self
             .peers
             .notify_iter()
@@ -122,7 +122,7 @@ impl Cache {
                 _ => None,
             })
             .collect();
-        let valid: HashSet<_> = self
+        let valid: Vec<_> = self
             .peers
             .notify_iter()
             .filter_map(|entry| match entry {
@@ -135,11 +135,11 @@ impl Cache {
 
     /// Returns a snaphost of cached.
     /// Note that the peer last time used value is not updated in the cache.
-    pub fn snapshot(&self) -> HashSet<PeerInfo> {
+    pub fn snapshot(&self) -> Vec<PeerInfo> {
         self.peers.peek_iter().map(|(_, peer)| *peer).collect()
     }
 
-    fn open_file(&self) -> crate::Res<FileHandler<HashSet<PeerInfo>>> {
+    fn open_file(&self) -> crate::Res<FileHandler<Vec<PeerInfo>>> {
         let fname = self
             .file_name
             .as_ref()
@@ -216,8 +216,7 @@ mod tests {
 
                 cache.read_file();
 
-                let addrs: Vec<SocketAddr> =
-                    cache.snapshot().iter().map(|peer| peer.addr).collect();
+                let addrs: Vec<_> = cache.snapshot().iter().map(|peer| peer.addr).collect();
                 assert!(addrs.contains(&ipv4_addr(1, 2, 3, 4, 4000)));
                 assert!(addrs.contains(&ipv4_addr(1, 2, 3, 5, 5000)));
             }
@@ -321,11 +320,37 @@ mod tests {
                     timeout: 120,
                 });
                 cache.read_file();
-                let addrs: Vec<SocketAddr> =
-                    cache.snapshot().iter().map(|peer| peer.addr).collect();
+                let addrs: Vec<_> = cache.snapshot().iter().map(|peer| peer.addr).collect();
                 assert_eq!(addrs.len(), 2);
                 assert!(addrs.contains(&ipv4_addr(1, 2, 3, 4, 4000)));
                 assert!(addrs.contains(&ipv4_addr(1, 2, 3, 5, 5000)));
+            }
+
+            #[test]
+            fn it_retains_cached_items_order() {
+                let tmp_fname: OsString = bootstrap_cache_tmp_file().into();
+                let mut cache = Cache::new(CacheConfig {
+                    file_name: Some(tmp_fname.clone()),
+                    max_size: 5,
+                    timeout: 120,
+                });
+                let _ = cache.put(peer_info_with_rand_key(ipv4_addr(1, 2, 3, 6, 6000)));
+                let _ = cache.put(peer_info_with_rand_key(ipv4_addr(1, 2, 3, 4, 4000)));
+                let _ = cache.put(peer_info_with_rand_key(ipv4_addr(1, 2, 3, 5, 5000)));
+
+                unwrap!(cache.commit());
+
+                let mut cache = Cache::new(CacheConfig {
+                    file_name: Some(tmp_fname),
+                    max_size: 5,
+                    timeout: 120,
+                });
+                cache.read_file();
+                let addrs: Vec<_> = cache.snapshot().iter().map(|peer| peer.addr).collect();
+                assert_eq!(addrs.len(), 3);
+                assert_eq!(addrs[0], ipv4_addr(1, 2, 3, 5, 5000));
+                assert_eq!(addrs[1], ipv4_addr(1, 2, 3, 4, 4000));
+                assert_eq!(addrs[2], ipv4_addr(1, 2, 3, 6, 6000));
             }
         }
     }

--- a/src/main/bootstrap/cache.rs
+++ b/src/main/bootstrap/cache.rs
@@ -104,6 +104,13 @@ impl Cache {
         Ok(())
     }
 
+    /// Calls `commit()` and if error happens just logs it.
+    pub fn try_commit(&self) {
+        if let Err(e) = self.commit() {
+            info!("Failed to write bootstrap cache to disk: {}", e);
+        }
+    }
+
     /// Returns cached peers.
     /// Moves returned peers to the top of the cache.
     pub fn peers(&mut self) -> (HashSet<PeerInfo>, HashSet<PeerInfo>) {

--- a/src/main/bootstrap/mod.rs
+++ b/src/main/bootstrap/mod.rs
@@ -181,9 +181,7 @@ impl Bootstrap {
                 {
                     let bootstrap_cache = &mut core.user_data_mut().bootstrap_cache;
                     bootstrap_cache.remove(&bad_peer);
-                    if let Err(e) = bootstrap_cache.commit() {
-                        info!("Failed to write bootstrap cache to disk: {}", e);
-                    }
+                    bootstrap_cache.try_commit();
                 }
 
                 if let Some(reason) = opt_reason {
@@ -278,9 +276,7 @@ pub fn cache_peer_info(core: &mut EventLoopCore, poll: &Poll, peer_info: PeerInf
     }
 
     let expired_peers = user_data.bootstrap_cache.put(peer_info);
-    if let Err(e) = user_data.bootstrap_cache.commit() {
-        info!("Failed to write bootstrap cache to disk: {}", e);
-    }
+    user_data.bootstrap_cache.try_commit();
     test_inactive_cached_peers(core, poll, expired_peers);
 }
 

--- a/src/main/bootstrap/mod.rs
+++ b/src/main/bootstrap/mod.rs
@@ -312,12 +312,11 @@ fn seek_peers(
 
 /// Peers to bootsrap off.
 fn bootstrap_peers(
-    mut cached_peers: HashSet<PeerInfo>,
+    cached_peers: Vec<PeerInfo>,
     config: &Config,
     blacklist: HashSet<SocketAddr>,
 ) -> Vec<PeerInfo> {
-    let mut peers: Vec<_> = cached_peers.drain().collect();
-
+    let mut peers = cached_peers;
     let mut hard_coded = config.hard_coded_contacts.clone();
     let mut rng = rand::thread_rng();
     hard_coded.shuffle(&mut rng);
@@ -404,8 +403,7 @@ mod tests {
             let peer2 = peer_info_with_rand_key(ipv4_addr(1, 2, 3, 5, 5000));
             let mut config = Config::default();
             config.hard_coded_contacts = vec![peer1];
-            let mut cached_peers = HashSet::new();
-            let _ = cached_peers.insert(peer2);
+            let cached_peers = vec![peer2];
 
             let peers = bootstrap_peers(cached_peers, &config, Default::default());
 
@@ -420,8 +418,7 @@ mod tests {
             let peer2 = peer_info_with_rand_key(ipv4_addr(1, 2, 3, 5, 5000));
             let mut config = Config::default();
             config.hard_coded_contacts = vec![peer1];
-            let mut cached_peers = HashSet::new();
-            let _ = cached_peers.insert(peer2);
+            let cached_peers = vec![peer2];
             let mut blacklisted = HashSet::new();
             let _ = blacklisted.insert(ipv4_addr(1, 2, 3, 4, 4000));
 

--- a/src/main/connect/mod.rs
+++ b/src/main/connect/mod.rs
@@ -205,9 +205,7 @@ impl Connect {
     fn remove_peer_from_cache(&self, core: &mut EventLoopCore, peer_info: &PeerInfo) {
         let bootstrap_cache = &mut core.user_data_mut().bootstrap_cache;
         bootstrap_cache.remove(peer_info);
-        if let Err(e) = bootstrap_cache.commit() {
-            info!("Failed to write bootstrap cache to disk: {}", e);
-        }
+        bootstrap_cache.try_commit();
     }
 
     fn maybe_terminate(&mut self, core: &mut EventLoopCore, poll: &Poll) {

--- a/src/main/service.rs
+++ b/src/main/service.rs
@@ -655,8 +655,8 @@ impl Service {
         self.our_uid.pub_enc_key
     }
 
-    /// Returns a list of peers stored in bootstrap cache.
-    pub fn bootstrap_cached_peers(&self) -> crate::Res<HashSet<PeerInfo>> {
+    /// Returns a list of peers stored in bootstrap cache ordered by the most recently used.
+    pub fn bootstrap_cached_peers(&self) -> crate::Res<Vec<PeerInfo>> {
         let (tx, rx) = mpsc::channel();
         let _ = self.post(move |core, _| {
             let cached_peers = core.user_data().bootstrap_cache.snapshot();

--- a/src/nat/mapped_tcp_socket/mod.rs
+++ b/src/nat/mapped_tcp_socket/mod.rs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-pub use self::get_ext_addr::GetExtAddr;
+pub use self::get_ext_addr::{Finish as GetExtAddrFinish, GetExtAddr};
 use crate::common::{Core, CoreMessage, CoreTimer, State};
 use crate::nat::{util, MappingContext, NatError};
 use igd::PortMappingProtocol;

--- a/src/nat/mod.rs
+++ b/src/nat/mod.rs
@@ -8,7 +8,7 @@
 // Software.
 
 pub use self::error::NatError;
-pub use self::mapped_tcp_socket::{GetExtAddr, MappedTcpSocket};
+pub use self::mapped_tcp_socket::{GetExtAddr, GetExtAddrFinish, MappedTcpSocket};
 pub use self::mapping_context::MappingContext;
 pub use self::util::ip_addr_is_global;
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -17,6 +17,7 @@ pub use self::utils::{
 use crate::common::{CrustUser, PeerInfo};
 use crate::main::{Config, Event, Service};
 use crate::PeerId;
+use hamcrest2::prelude::*;
 use mio;
 use rand;
 use safe_crypto::{gen_encrypt_keypair, PublicEncryptKey};
@@ -72,7 +73,7 @@ mod connect {
         });
         let pub_ci1 = unwrap!(ci_rx1.recv());
         let pub_key1 = pub_ci1.id.pub_enc_key;
-        let expected_conns: HashSet<PeerInfo> = pub_ci1
+        let expected_conns: Vec<PeerInfo> = pub_ci1
             .for_direct
             .iter()
             .map(|addr| PeerInfo::new(*addr, pub_key1))
@@ -84,7 +85,7 @@ mod connect {
         });
 
         let cached_peers = unwrap!(service2.bootstrap_cached_peers());
-        assert!(cached_peers.is_subset(&expected_conns));
+        assert_that!(&expected_conns, contains(cached_peers));
     }
 
     #[test]


### PR DESCRIPTION
1. After peer inactivity timeout, peer contacts are evicted from the bootstrap cache.
2. Then cache validator picks this peer up and sends some request to it to see, if it's alive.
3. If peer responds within some time, it is readded to the bootstrap cache.
4. The problem was that in this case bootstrap cache was not flushed to disk. This PR fixes that.