### PR TITLE
closes #835: update bootstrap cache on msg send

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
     improper_ctypes,
     missing_docs,
     non_shorthand_field_patterns,
+    nonstandard_style,
     overflowing_literals,
     plugin_as_library,
     stable_features,

--- a/src/main/active_connection.rs
+++ b/src/main/active_connection.rs
@@ -100,30 +100,31 @@ impl ActiveConnection {
     }
 
     fn read(&mut self, core: &mut EventLoopCore, poll: &Poll) {
+        let mut msg_received = false;
         loop {
             match self.socket.read::<Message>() {
                 Ok(Some(Message::Data(data))) => {
                     let _ =
                         self.event_tx
                             .send(Event::NewMessage(self.their_id, self.their_role, data));
-                    self.reset_receive_heartbeat(core, poll);
-                    self.updated_bootstrap_cache(core, poll);
+                    msg_received = true;
                 }
-                Ok(Some(Message::Heartbeat)) => {
-                    self.reset_receive_heartbeat(core, poll);
-                    self.updated_bootstrap_cache(core, poll);
-                }
+                Ok(Some(Message::Heartbeat)) => msg_received = true,
                 Ok(Some(message)) => {
                     debug!("{:?} - Unexpected message: {:?}", self.our_id, message);
-                    self.reset_receive_heartbeat(core, poll);
-                    self.updated_bootstrap_cache(core, poll);
+                    msg_received = true;
                 }
-                Ok(None) => return,
+                Ok(None) => break,
                 Err(e) => {
                     debug!("{:?} - Failed to read from socket: {:?}", self.our_id, e);
                     return self.terminate(core, poll);
                 }
             }
+        }
+
+        if msg_received {
+            self.reset_receive_heartbeat(core, poll);
+            self.update_bootstrap_cache(core, poll);
         }
     }
 
@@ -150,7 +151,7 @@ impl ActiveConnection {
             debug!("{:?} - Failed to write socket: {:?}", self.our_id, e);
             self.terminate(core, poll);
         } else {
-            self.updated_bootstrap_cache(core, poll);
+            self.update_bootstrap_cache(core, poll);
         }
     }
 
@@ -169,7 +170,7 @@ impl ActiveConnection {
     }
 
     /// If peer we are communicating with is in bootstrap cache, move it to the top of the cache.
-    fn updated_bootstrap_cache(&mut self, core: &mut EventLoopCore, poll: &Poll) {
+    fn update_bootstrap_cache(&mut self, core: &mut EventLoopCore, poll: &Poll) {
         let expired_peers = core.user_data_mut().bootstrap_cache.touch(&self.peer_info);
         core.user_data_mut().bootstrap_cache.try_commit();
         test_inactive_cached_peers(core, poll, expired_peers);
@@ -302,6 +303,7 @@ mod tests {
     use hamcrest2::prelude::*;
     use mio::{Events, Poll, PollOpt, Ready, Token};
     use std::net::TcpListener;
+    use std::sync::mpsc;
     use std::thread;
 
     fn wait_until_connected(sock: &TcpSock) {
@@ -314,6 +316,73 @@ mod tests {
             for ev in events.iter() {
                 match ev.token() {
                     SOCKET_TOKEN => return,
+                    _ => panic!("Unexpected event"),
+                }
+            }
+        }
+    }
+
+    fn wait_for(token: Token, el: &Poll) {
+        let mut events = Events::with_capacity(16);
+        loop {
+            unwrap!(el.poll(&mut events, None));
+            for ev in events.iter() {
+                if ev.token() == token {
+                    return;
+                } else {
+                    panic!("Unexpected event");
+                }
+            }
+        }
+    }
+
+    /// Spawns connection listener that accepts single connection and sends some dummy message to
+    /// it.
+    ///
+    /// Returns listener port.
+    fn spawn_listener(port_tx: mpsc::Sender<u16>) {
+        use mio::net::TcpListener;
+
+        let listener = unwrap!(TcpListener::bind(&ipv4_addr(0, 0, 0, 0, 0)));
+        let listener_port = unwrap!(listener.local_addr()).port();
+        unwrap!(port_tx.send(listener_port));
+        let mut socket = None;
+
+        const LISTENER_TOKEN: Token = Token(0);
+        const SOCKET_TOKEN: Token = Token(1);
+
+        let el = unwrap!(Poll::new());
+        unwrap!(el.register(
+            &listener,
+            LISTENER_TOKEN,
+            Ready::readable(),
+            PollOpt::edge()
+        ));
+
+        let mut events = Events::with_capacity(16);
+        loop {
+            unwrap!(el.poll(&mut events, None));
+            for ev in events.iter() {
+                match ev.token() {
+                    LISTENER_TOKEN => {
+                        let (sock, _) = unwrap!(listener.accept());
+                        let sock = TcpSock::wrap(sock);
+                        unwrap!(el.register(
+                            &sock,
+                            SOCKET_TOKEN,
+                            Ready::writable(),
+                            PollOpt::edge()
+                        ));
+                        socket = Some(sock);
+                    }
+                    SOCKET_TOKEN => {
+                        if let Some(ref mut sock) = socket {
+                            let buffered =
+                                unwrap!(sock.write(Some((Message::Data(vec![1, 2, 3]), 1))));
+                            assert!(buffered);
+                            unwrap!(el.deregister(sock));
+                        }
+                    }
                     _ => panic!("Unexpected event"),
                 }
             }
@@ -370,6 +439,68 @@ mod tests {
                 let mut state = state.borrow_mut();
                 let active_conn = unwrap!(state.as_any().downcast_mut::<ActiveConnection>());
                 active_conn.write(&mut core, &poll, None);
+
+                let cached_addrs: Vec<_> = core
+                    .user_data()
+                    .bootstrap_cache
+                    .snapshot()
+                    .iter()
+                    .map(|peer| peer.addr)
+                    .collect();
+                assert_that!(
+                    &cached_addrs,
+                    contains(vec![peer1_addr, ipv4_addr(1, 2, 3, 4, 4000),])
+                        .in_order()
+                        .exactly()
+                );
+            }
+        }
+
+        mod read {
+            use super::*;
+
+            #[test]
+            fn it_moves_peer_to_the_top_of_the_bootstrap_cache() {
+                let (tx, rx) = mpsc::channel();
+                let _listener_thread = thread::spawn(move || spawn_listener(tx));
+                let listener_port = unwrap!(rx.recv());
+
+                let poll = unwrap!(Poll::new());
+                let sock_token = Token(1);
+                let (peer1_id, _) = rand_peer_id_and_enc_sk();
+                let peer1_sock = unwrap!(TcpSock::connect(&ipv4_addr(127, 0, 0, 1, listener_port)));
+                unwrap!(poll.register(&peer1_sock, sock_token, Ready::writable(), PollOpt::edge()));
+
+                wait_for(sock_token, &poll);
+                let peer1_addr = unwrap!(peer1_sock.peer_addr());
+                let peer1_info = PeerInfo::new(peer1_addr, peer1_id.pub_enc_key);
+
+                let mut cache = bootstrap::Cache::new(Default::default());
+                let _ = cache.put(peer1_info);
+                let _ = cache.put(peer_info_with_rand_key(ipv4_addr(1, 2, 3, 4, 4000)));
+
+                let mut core = test_core(cache);
+                let (event_tx, _event_rx) = get_event_sender();
+                let (our_id, _) = rand_peer_id_and_enc_sk();
+                let event = Event::ConnectSuccess(peer1_id);
+                ActiveConnection::start(
+                    &mut core,
+                    &poll,
+                    sock_token,
+                    peer1_sock,
+                    our_id,
+                    peer1_id,
+                    CrustUser::Client,
+                    event,
+                    event_tx,
+                );
+
+                let state = unwrap!(core.get_state(sock_token));
+                let mut state = state.borrow_mut();
+                let active_conn = unwrap!(state.as_any().downcast_mut::<ActiveConnection>());
+                wait_for(sock_token, &poll);
+                //std::thread::sleep(Duration::from_secs(2));
+                active_conn.read(&mut core, &poll);
 
                 let cached_addrs: Vec<_> = core
                     .user_data()

--- a/src/main/bootstrap/mod.rs
+++ b/src/main/bootstrap/mod.rs
@@ -12,8 +12,7 @@ mod cache_validator;
 mod try_peer;
 
 pub use self::cache::{Cache, CacheConfig};
-use self::cache_validator::test_inactive_cached_peers;
-pub use self::cache_validator::CacheValidator;
+pub use self::cache_validator::{test_inactive_cached_peers, CacheValidator};
 use self::try_peer::TryPeer;
 use crate::common::{
     BootstrapDenyReason, BootstrapperRole, CoreTimer, CrustUser, NameHash, PeerInfo, State,


### PR DESCRIPTION
Move peer to the top of the bootstrap cache, if we are sending a message to it. That means this peer is the most active.